### PR TITLE
chore(release): gi-plugins v1.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lee-internal-comps",
       "source": "./plugins/lee-internal-comps",
       "description": "Internal (Dealius) and external (CoStar) lease & sale comps for Lee & Associates Raleigh brokers. Two skills: internal-comps (Dealius, Excel + Lee-branded PDF) and external-comps (CoStar weekly snapshot via typed MCP tools, Excel + Markdown table; PDF deferred to v1.1).",
-      "version": "0.7.1"
+      "version": "1.4.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to the `gi-plugins` marketplace (the `lee-internal-comps` plugin for
+Lee & Associates Raleigh brokers). Follows [Semantic Versioning](https://semver.org/).
+
+Brokers pick up releases by syncing the marketplace in Cowork (auto-sync toggle on), or
+via `/plugin update`. `marketplace.json` and `plugins/lee-internal-comps/.claude-plugin/plugin.json`
+carry the same version as of 1.4.0.
+
+## [1.4.0] - 2026-05-29
+
+First tagged release since `v1.1.0`. Consolidates the 1.2.0–1.3.4 work (which shipped to
+brokers via commit-sync but was never tagged) into one clean release, and re-syncs the
+two version manifests (`marketplace.json` had drifted to 0.7.1).
+
+### Added
+- **owner-lookup skill** — owner of record, mailing address, and assessor facts for any
+  property in Wake, Durham, New Hanover, or Lee NC, sub-second from a bulk-staged owner
+  graph (~2M parcels). (1.2.0)
+- **daily-debrief skill** — Will-facing interview-style classification of yesterday's
+  broker requests, capturing off-plugin asks (plugin_broke / known_gap / new_opportunity)
+  so the rollup drives the roadmap conversation. (1.3.0)
+
+### Changed
+- Comps skills now **surface the data freshness banner** so brokers can see how current
+  the Dealius/CoStar data is before relying on it.
+- `internal-comps` description corrected to advertise **both lease and sale** comps (it
+  previously read lease-only).
+
+### Fixed
+- **Excel export filenames** on Windows — short, flat filenames + a `format_excel` guard
+  for the 218-character path limit Will hit (roadmap #61).
+
+### Internal (not broker-facing)
+- skill-contract-check pre-commit hook + reviewer tooling (`scripts/`).
+- PR template for the plugin-development-process.
+- Version manifests re-synced: `marketplace.json` + `plugin.json` both `1.4.0`.
+
+## [1.1.0] - earlier
+Last previously-tagged release. See git history before this changelog existed.

--- a/plugins/lee-internal-comps/.claude-plugin/plugin.json
+++ b/plugins/lee-internal-comps/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lee-internal-comps",
   "description": "Internal (Dealius) and external (CoStar) lease & sale comps, demographic reports, and owner-of-record lookup for authorized Lee & Associates Raleigh brokers. Six skills: internal-comps (Dealius mirror, Excel + Lee-branded PDF), external-comps (CoStar weekly snapshot via typed MCP tools, Excel + Markdown table), demographic-summary (1/3/5 mi single-page Lee infographic for any NC address, JSON + Lee-branded PDF with 1-hour signed link), demographic-detail (multi-page Demographic and Income Profile with inline SVG charts, race/income breakdowns, 2020/2025/2030 projections via gi_permit_adjusted with Census BPS add-back, Family HHs + Owner HUs trend bars, four Esri-analog indices, and Lee-branded PDF), business-key-facts (BAO-style Business Key Facts 3-page landscape PDF for any NC address: key statistics, households table, site map with 1/3/5 mile rings, education attainment + workforce charts, population/housing growth), and owner-lookup (owner of record + mailing address + assessor facts for any property in Wake, Durham, New Hanover, or Lee NC, sub-second from a bulk-staged D1 owner graph of ~2M parcels/owners/links), and daily-debrief (Will-only interview-style classification of yesterday's broker requests: walks through each plugin session AND each off-plugin ask one-by-one, capturing the off-plugin category (plugin_broke / known_gap / new_opportunity) so the rollup drives the roadmap conversation).",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "author": {
     "name": "Grounded Intelligence"
   },


### PR DESCRIPTION
Release ceremony for gi-plugins v1.4.0 (Stage 3 of plugin-development-process).

- Bump `plugin.json` 1.3.4 -> 1.4.0
- Re-sync `marketplace.json` (had drifted to 0.7.1) -> 1.4.0
- Add first `CHANGELOG.md`

Consolidates the untagged 1.2.0-1.3.4 run (owner-lookup, daily-debrief, freshness banner, Excel long-path fix) into one clean tagged release. Closes milestone gi-plugins v1.4.0 (#3 #4 #5 #7). Tag `v1.4.0` stamped after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)