### PR TITLE
fix(internal-comps): $/Acre instead of $/SF for LAND sale comps (Excel)

### DIFF
--- a/plugins/lee-internal-comps/skills/internal-comps/SKILL.md
+++ b/plugins/lee-internal-comps/skills/internal-comps/SKILL.md
@@ -135,6 +135,8 @@ The mirror exposes both `lease_comps_safe` and `sale_comps_safe`. `build_sql` br
 
 Sale uses a different display layout (`DISPLAY_COLUMNS_SALE`) and stat shape (sale price, $/SF, total volume) — both selected automatically by `format_excel` based on `validated["transaction_type"]`. Sheet name inserts `Sale` between asset and geography (e.g., `"Industrial Sale Garner, Raleigh Comps"`).
 
+**LAND sale exception:** when `asset_type == "land"` on a sale pull, `format_excel` uses `DISPLAY_COLUMNS_SALE_LAND`, which swaps the `$/SF` column for `$/Acre` (`price_per_acre = sale_price / acres`, computed in-loop, blank when acres is null/zero). The `Acres` column is retained; all other columns and the color scale are unchanged. $/SF is meaningless for raw land — brokers price land by acreage (broker request, gi-plugins#28).
+
 ## Confidentiality
 
 Confidential and NDA rows are filtered server-side at the `lease_comps_safe` view. The model never sees them.

--- a/plugins/lee-internal-comps/skills/internal-comps/helpers.py
+++ b/plugins/lee-internal-comps/skills/internal-comps/helpers.py
@@ -454,6 +454,15 @@ DISPLAY_COLUMNS_SALE: list[tuple[str, str]] = [
     ("Comp Profile",     "link_to_comp_profile"),
 ]
 
+# Land sale variant: brokers price raw land by acreage, so swap the $/SF column
+# (col 12) for $/Acre (price_per_acre, computed sale_price/acres). Same column
+# count and positions as DISPLAY_COLUMNS_SALE so format_excel's positional
+# index sets stay valid; the "Acres" column (col 8) is retained.
+DISPLAY_COLUMNS_SALE_LAND: list[tuple[str, str]] = [
+    ("$/Acre", "price_per_acre") if key == "price_per_sf" else (label, key)
+    for label, key in DISPLAY_COLUMNS_SALE
+]
+
 ASSET_TITLE_MAP: dict[str, str] = {
     "industrial":     "Industrial",
     "flex":           "Flex",
@@ -831,9 +840,16 @@ def format_excel(
     asset_title = _asset_title(validated.get("asset_type", ""))
     geo_label = _geography_label(validated.get("geography", {}))
     is_sale = validated.get("transaction_type") == "sale"
+    # LAND sale comps price on $/Acre, not $/SF (broker request, gi-plugins#28).
+    is_land_sale = is_sale and validated.get("asset_type") == "land"
     txn_token = " Sale" if is_sale else ""
     sheet_name = f"{asset_title}{txn_token} {geo_label} Comps".strip().replace("  ", " ")
-    display_columns = DISPLAY_COLUMNS_SALE if is_sale else DISPLAY_COLUMNS_LEASE
+    if is_land_sale:
+        display_columns = DISPLAY_COLUMNS_SALE_LAND
+    elif is_sale:
+        display_columns = DISPLAY_COLUMNS_SALE
+    else:
+        display_columns = DISPLAY_COLUMNS_LEASE
 
     wb = Workbook()
     default_font = Font(name="Calibri", size=11)
@@ -888,15 +904,21 @@ def format_excel(
             int_cols = {7, 9}                          # Building SF, Year Built
             acres_cols = {8}                           # Acres (decimal)
             large_money_cols = {10, 11}                # Asking Price, Sale Price
-            money_per_sf_cols = {12}                   # $/SF
             pct_cols = {13, 14}                        # Asking Cap %, Actual Cap %
-            color_scale_col = "L"                      # $/SF
+            color_scale_col = "L"                      # col 12: $/SF, or $/Acre for land
+            if is_land_sale:
+                money_per_sf_cols = set()
+                money_per_acre_cols = {12}             # $/Acre (whole dollars)
+            else:
+                money_per_sf_cols = {12}               # $/SF
+                money_per_acre_cols = set()
         else:
             left_align_cols = {3, 4, 5, 6, 15, 19, 20, 21, 22, 23}
             int_cols = {7, 8, 16}                      # SF, free rent months
             acres_cols = set()
             large_money_cols = set()
             money_per_sf_cols = {12, 13, 14, 17}       # asking, base, effective, TI
+            money_per_acre_cols = set()
             pct_cols = {18}                            # avg escalation
             color_scale_col = "N"                      # Effective $/SF
 
@@ -910,9 +932,17 @@ def format_excel(
                     raw = row.get("square_feet_sold")
                 if is_sale and key == "square_feet_sold" and (raw is None or raw == ""):
                     raw = row.get("building_size")
+                # $/Acre is computed, not stored: sale_price / acres. Blank (not
+                # an error) when acres is null or zero.
+                if key == "price_per_acre":
+                    sp = _to_number(row.get("sale_price"))
+                    ac = _to_number(row.get("acres"))
+                    raw = (sp / ac) if (
+                        isinstance(sp, (int, float)) and isinstance(ac, (int, float)) and ac
+                    ) else None
                 if col_idx in int_cols:
                     val = _to_int(raw)
-                elif col_idx in (money_per_sf_cols | large_money_cols | pct_cols | acres_cols):
+                elif col_idx in (money_per_sf_cols | money_per_acre_cols | large_money_cols | pct_cols | acres_cols):
                     val = _to_number(raw)
                 else:
                     val = raw
@@ -933,6 +963,8 @@ def format_excel(
                     ws.cell(row=r, column=col_idx).number_format = "$#,##0"
                 for col_idx in money_per_sf_cols:
                     ws.cell(row=r, column=col_idx).number_format = "$#,##0.00"
+                for col_idx in money_per_acre_cols:
+                    ws.cell(row=r, column=col_idx).number_format = "$#,##0"
                 for col_idx in pct_cols:
                     ws.cell(row=r, column=col_idx).number_format = '0.0"%"'
 

--- a/plugins/lee-internal-comps/tests/test_land_price_per_acre.py
+++ b/plugins/lee-internal-comps/tests/test_land_price_per_acre.py
@@ -1,0 +1,141 @@
+"""
+Tests for LAND sale comps showing $/Acre in place of $/SF (Excel).
+
+Broker request (Mike Glennon, Lee, 2026-06-02): for LAND sale comps the Excel
+should price on $/Acre, not $/SF. $/SF is meaningless for raw land.
+
+Card: davidmshaner-gi/gi-plugins#28.
+"""
+
+import os
+import sys
+import tempfile
+
+import pytest
+from openpyxl import load_workbook
+
+SKILL_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "skills",
+    "internal-comps",
+)
+sys.path.insert(0, SKILL_DIR)
+
+import helpers  # noqa: E402
+
+
+def _find_header_row(ws):
+    """The header row is the row whose first column is 'Comp ID'."""
+    for r in range(1, 8):
+        if ws.cell(row=r, column=1).value == "Comp ID":
+            return r
+    raise AssertionError("header row not found")
+
+
+def _col_index(ws, header_row, label):
+    """1-based column index of the header `label` on `header_row`."""
+    c = 1
+    while ws.cell(row=header_row, column=c).value is not None:
+        if ws.cell(row=header_row, column=c).value == label:
+            return c
+        c += 1
+    raise AssertionError(f"header {label!r} not found")
+
+
+def _build(rows, asset_type, transaction_type="sale"):
+    """Run format_excel and return the loaded Comps worksheet.
+
+    format_excel flattens output_path to a basename and saves into the CWD
+    (the Windows long-path guard), returning the actual path it wrote. Run in
+    a temp dir and load the returned path.
+    """
+    validated = {
+        "asset_type": asset_type,
+        "transaction_type": transaction_type,
+        "geography": {"named_market": "Triangle"},
+    }
+    with tempfile.TemporaryDirectory() as d:
+        cwd = os.getcwd()
+        os.chdir(d)
+        try:
+            result = helpers.format_excel(rows, validated, "comps.xlsx", [], [])
+            wb = load_workbook(result["path"])
+        finally:
+            os.chdir(cwd)
+    return wb[wb.sheetnames[0]]
+
+
+# A land sale row with a clean acres value.
+LAND_ROW = {
+    "comps_id": "L-1",
+    "comp_name": "Raw Land Tract",
+    "street_address": "123 Farm Rd",
+    "city": "Sanford",
+    "county": "Lee",
+    "acres": 10.0,
+    "sale_price": 2_500_000,
+    "price_per_sf": 5.74,  # present in data but should be ignored for land
+}
+
+
+def test_land_sale_header_is_price_per_acre():
+    ws = _build([LAND_ROW], asset_type="land")
+    hr = _find_header_row(ws)
+    headers = [ws.cell(row=hr, column=c).value for c in range(1, 24)]
+    assert "$/Acre" in headers
+    assert "$/SF" not in headers
+
+
+def test_land_sale_keeps_acres_column():
+    ws = _build([LAND_ROW], asset_type="land")
+    hr = _find_header_row(ws)
+    headers = [ws.cell(row=hr, column=c).value for c in range(1, 24)]
+    assert "Acres" in headers  # the Acres column must remain
+
+
+def test_land_sale_price_per_acre_value_is_computed():
+    ws = _build([LAND_ROW], asset_type="land")
+    hr = _find_header_row(ws)
+    col = _col_index(ws, hr, "$/Acre")
+    # 2,500,000 / 10 acres = 250,000
+    assert ws.cell(row=hr + 1, column=col).value == pytest.approx(250_000)
+
+
+def test_land_sale_zero_and_null_acres_render_blank_no_error():
+    rows = [
+        {**LAND_ROW, "comps_id": "L-zero", "acres": 0},
+        {**LAND_ROW, "comps_id": "L-null", "acres": None},
+    ]
+    ws = _build(rows, asset_type="land")
+    hr = _find_header_row(ws)
+    col = _col_index(ws, hr, "$/Acre")
+    assert ws.cell(row=hr + 1, column=col).value is None  # zero acres -> blank
+    assert ws.cell(row=hr + 2, column=col).value is None  # null acres -> blank
+
+
+def test_land_sale_price_per_acre_number_format_is_currency():
+    ws = _build([LAND_ROW], asset_type="land")
+    hr = _find_header_row(ws)
+    col = _col_index(ws, hr, "$/Acre")
+    assert ws.cell(row=hr + 1, column=col).number_format == "$#,##0"
+
+
+def test_non_land_sale_unchanged_shows_price_per_sf():
+    industrial_row = {
+        "comps_id": "I-1",
+        "comp_name": "Warehouse",
+        "street_address": "9 Industry Way",
+        "city": "Durham",
+        "county": "Durham",
+        "square_feet_sold": 50_000,
+        "acres": 3.0,
+        "sale_price": 6_000_000,
+        "price_per_sf": 120.0,
+    }
+    ws = _build([industrial_row], asset_type="industrial")
+    hr = _find_header_row(ws)
+    headers = [ws.cell(row=hr, column=c).value for c in range(1, 24)]
+    assert "$/SF" in headers
+    assert "$/Acre" not in headers
+    col = _col_index(ws, hr, "$/SF")
+    assert ws.cell(row=hr + 1, column=col).value == pytest.approx(120.0)


### PR DESCRIPTION
## What changed
LAND sale comps now show a `$/Acre` column (price_per_acre = sale_price / acres) in the Excel where `$/SF` used to be; the `Acres` column stays, and non-land asset types are unchanged.

## Checklist
- [x] Linked to issue (Part of davidmshaner-gi/gi-plugins#28 — Excel half; PDF half ships separately in lee-raleigh-mcp)
- [x] Version bump needed? (N → bundled into next gi-plugins v1.5.0 release)
- [x] CHANGELOG.md updated if broker-visible (deferred to release ceremony per process Stage 3c)
- [x] skill-contract-check passed (gi-plugins only)
- [x] verification-before-completion run
- [x] Worktree cleanup planned for after merge

## Detail
- `DISPLAY_COLUMNS_SALE_LAND` swaps the `$/SF`/`price_per_sf` tuple for `$/Acre`/`price_per_acre`; same column count + positions so `format_excel`'s positional index sets stay valid.
- `price_per_acre` is computed in-loop (`sale_price / acres`), blank when acres is null/zero — no divide-by-zero.
- Number format `$#,##0` (whole dollars) + the existing color scale on col 12.
- 6 new tests in `plugins/lee-internal-comps/tests/test_land_price_per_acre.py`; TDD red→green. Lease + non-land sale paths verified unchanged.

Broker request from Mike Glennon (Lee), relayed by David 2026-06-02.