### PR TITLE
chore(owner-lookup): verify-footer link QA harness (Closes #19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/

--- a/scripts/qa/verify-links/.gitignore
+++ b/scripts/qa/verify-links/.gitignore
@@ -1,0 +1,3 @@
+# Run artifacts (report.md + per-county screenshots). Regenerated every run;
+# current-state results live in README.md instead.
+out/

--- a/scripts/qa/verify-links/README.md
+++ b/scripts/qa/verify-links/README.md
@@ -30,6 +30,12 @@ session cookie. Only a real browser submit reproduces what the broker experience
 The sentinel PINs are the real worked-example parcels from the SKILL.md footer, so
 this file and the skill always agree on what "good" looks like.
 
+**Coverage note:** Durham / NHC / Lee are full *form-submit* checks (fill the search
+box, submit, assert the result). Wake has no search form — the `?pin=` URL *is* the
+round-trip — so Wake is a *deep-link-resolution* check: it confirms the parcel pane
+resolves the PIN. A Wake regression in pane resolution is caught; there is no separate
+"search path" to break for Wake.
+
 ## Current state (last full run: 2026-06-02)
 
 | County | Result | Baseline | Notes |

--- a/scripts/qa/verify-links/README.md
+++ b/scripts/qa/verify-links/README.md
@@ -1,0 +1,114 @@
+# owner-lookup verify-link QA
+
+Catches a broken county **verify-footer** link before a broker does.
+
+The `owner-lookup` skill ends every response with a freshness footer that links the
+broker to the authoritative county portal and tells them to paste a PIN to confirm
+the data (see `plugins/lee-internal-comps/skills/owner-lookup/SKILL.md`). If that
+link's search form silently changes — a renamed search mode, a moved form field —
+the broker finds out mid-deal, on an offer letter. This harness pushes a real PIN
+through each portal's **actual search form** and asserts the parcel comes back.
+
+## Why a browser and not `curl`
+
+Every one of these portals returns **HTTP 200 on the search page even when the
+search itself is broken**. A load-only check (`curl … | grep 200`) passes on all
+four — including Lee, where the form loads fine and then throws `An Error has
+Occurred` the moment you submit a PIN (the bug in gi-plugins #18 / lee-and-associates
+#18). Tyler iasWorld portals also gate behind a click-through disclaimer that sets a
+session cookie. Only a real browser submit reproduces what the broker experiences.
+
+## What it checks
+
+| County | Portal | How the PIN round-trips | Sentinel PIN |
+|---|---|---|---|
+| Wake | Wake iMaps | `?pin=` deep-link → accept disclaimer → assert info pane shows the parcel | `0734835370` |
+| Durham | Durham Tax CAMA | PIN tab → fill PIN box → search → assert PropertySummary | `0822419440` |
+| New Hanover | NHC etax (Tyler iasWorld) | accept disclaimer → `#inpParid` → `#btSearch` → assert results row | `R04720-007-011-000` |
+| Lee | Lee County Tax Access (Tyler iasWorld) | same Tyler flow | `9645-45-9484-00` |
+
+The sentinel PINs are the real worked-example parcels from the SKILL.md footer, so
+this file and the skill always agree on what "good" looks like.
+
+## Current state (last full run: 2026-06-02)
+
+| County | Result | Baseline | Notes |
+|---|---|---|---|
+| Wake | ✅ PASS | pass | `100 CONNEMARA DR` / PNC OF NORTH CAROLINA LLC renders in the info pane |
+| Durham | ✅ PASS | pass | resolves to `PropertySummary.aspx?PIN=0822419440` (DUKE UNIVERSITY) |
+| New Hanover | ✅ PASS | pass | results row echoes `R04720-007-011-000` |
+| Lee | ❌ FAIL | **fail (known #18)** | `mode=parid` throws `An Error has Occurred` on submit. Expected-broken until the sibling fix flips the footer to a working search mode (`mode=realprop`). |
+
+4/4 match baseline → exit 0. Had this harness existed, it would have caught the Lee
+bug. NHC was "TBD" in the issue; this run confirms it **passes**.
+
+## Run it
+
+```bash
+cd scripts/qa/verify-links
+pip install -r requirements.txt
+python3 -m playwright install chromium      # one-time, fetches the browser binary
+python3 verify_links.py                       # all counties; writes out/report.md + out/<county>.png
+```
+
+Options: `--county LEE` (one county), `--headed` (watch it drive), `--out <dir>`,
+`--no-screenshots`. Full run is ~30s.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Every county checked matches its baseline. Safe. |
+| `1` | A county **diverged** from baseline — a regression or an unexpected fix (see below). |
+| `2` | Harness error driving a portal (timeout, crash) — investigate, not necessarily a real failure. |
+
+## Baseline model — how it stays honest
+
+Each county's known-good state is the `expected` field in `counties.py`. The harness
+only fails loudly (exit 1) when **live state diverges from baseline**:
+
+- **A passing county now FAILS → `REGRESSION`.** The portal or our linked URL
+  changed; brokers are blocked. Fix the SKILL.md footer (and `counties.py`) before
+  the next release.
+- **A known-broken county now PASSES → `FIXED`.** The bug got fixed elsewhere (e.g.
+  Lee #18 lands). Flip that county's `expected` to `pass` in `counties.py` and update
+  the SKILL.md footer to the now-working URL.
+
+A *steady* known-broken county (Lee today) is reported but does **not** fail the run,
+so this can gate releases without being permanently blocked by a separately-tracked
+bug. Divergences are retried once automatically to absorb a flaky-portal blip before
+they're trusted.
+
+## When to run it
+
+- **Pre-release (recommended):** before tagging a `gi-plugins` release that touched
+  `owner-lookup` — part of Stage 3a (diff-against-last-tag) in the GI
+  plugin-development-process. A red run means a broker-facing link rotted.
+- **Ad-hoc:** any time the owner-lookup verification footer table changes (a new
+  county, a changed URL/mode, a new sentinel PIN). Update `counties.py` to match the
+  SKILL.md, then run.
+
+## Adding a county
+
+1. Add the county's footer row to the SKILL.md table (URL + sentinel PIN).
+2. Add a `County(...)` entry in `counties.py` (mirror the SKILL.md values; pick an
+   `adapter`; set `expect_any` to a token the result page will show; set `expected`).
+3. If the portal is a new kind, add an adapter function in `adapters.py` and register
+   it in `ADAPTERS`. The two Tyler iasWorld portals already share `tyler_iasworld`.
+4. `python3 verify_links.py --county <KEY> --headed` until it passes, then commit.
+
+## Files
+
+| File | Role |
+|---|---|
+| `verify_links.py` | CLI + harness: runs adapters, retries divergences once, renders the report, sets exit code |
+| `counties.py` | The registry + baseline. Single source of truth, mirrors the SKILL.md footer table |
+| `adapters.py` | Per-portal drivers: `wake_imaps`, `durham_cama`, `tyler_iasworld` (NHC + Lee) |
+| `test_verify_links.py` | Offline unit tests for the decision logic (no network) — `python3 test_verify_links.py` |
+| `requirements.txt` | `playwright` (browser binary fetched separately) |
+
+## Constraints
+
+- **Offline QA tooling only.** This never runs on the broker request path — gotcha G2
+  (no county API on the request path). `owner-lookup` reads only from D1 at request
+  time; this harness hits the county sites out-of-band, pre-release.

--- a/scripts/qa/verify-links/adapters.py
+++ b/scripts/qa/verify-links/adapters.py
@@ -1,0 +1,153 @@
+"""Per-portal adapters for the owner-lookup verify-link QA harness.
+
+An adapter drives ONE kind of county portal end-to-end: load the page, clear any
+disclaimer, push the sentinel PIN through the REAL search form, and report
+whether the result page actually shows that parcel. This is the whole point of
+the QA -- a plain HTTP GET would 200 on every portal even when the search form
+is broken (see Lee, mode=parid). Only a real form submit catches that.
+
+Each adapter returns a Probe. Adapters never raise for an expected portal state
+(error page, no results); they catch and report it as found=False so the harness
+can render a clean verdict. They only let truly unexpected exceptions bubble.
+"""
+
+from dataclasses import dataclass
+
+from playwright.sync_api import Page, TimeoutError as PWTimeout
+
+# Substrings (matched case-insensitively against the result body) that mean the
+# PIN search did NOT land on a real parcel -- a thrown error or an empty result.
+FAILURE_MARKERS = (
+    "an error has occurred",
+    "system encountered a problem",
+    "cannot complete the requested action",
+    "no records",
+    "0 records",
+    "no results",
+    "no parcels",
+    "not found",
+    "invalid",
+)
+
+
+@dataclass
+class Probe:
+    found: bool      # did the sentinel PIN round-trip to a real parcel detail?
+    detail: str      # broker-legible one-liner
+    final_url: str   # where we ended up (useful when a portal redirects on error)
+
+
+def _norm(s: str) -> str:
+    """Alphanumeric-only, uppercased -- so '0822-41-9440' matches '0822419440'."""
+    return "".join(ch for ch in s if ch.isalnum()).upper()
+
+
+def _assert_parcel(body: str, county) -> tuple[bool, str]:
+    """Generic result check: an expected token is present and no failure marker is."""
+    low = body.lower()
+    for marker in FAILURE_MARKERS:
+        if marker in low:
+            return False, f"result page shows '{marker}' -- search form rejected the PIN"
+    nbody = _norm(body)
+    for token in county.expect_any:
+        if _norm(token) in nbody:
+            return True, f"parcel detail confirmed (matched {token!r})"
+    return False, (
+        "page loaded but the parcel detail did not show the expected PIN/owner "
+        f"({', '.join(county.expect_any)}) -- the form may have silently changed"
+    )
+
+
+def _click_first_visible(page: Page, texts) -> bool:
+    for t in texts:
+        try:
+            btn = page.query_selector(f"button:has-text('{t}')") or page.query_selector(
+                f"input[type=submit][value='{t}']"
+            )
+            if btn and btn.is_visible():
+                btn.click()
+                return True
+        except PWTimeout:
+            continue
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# WAKE -- Wake iMaps. A JS map SPA reached by a ?pin= deep-link. There is no
+# form to submit; the deep-link IS the round-trip. We accept the one-time
+# disclaimer and assert the parcel info pane renders the PIN + owner.
+# --------------------------------------------------------------------------- #
+def wake_imaps(page: Page, county) -> Probe:
+    page.goto(county.url, wait_until="domcontentloaded")
+    page.wait_for_timeout(4000)  # the map app hydrates slowly
+    _click_first_visible(page, ["OK", "I Agree", "Agree", "Accept", "Continue", "Acknowledge"])
+    # Give the info pane time to resolve the pin and populate.
+    deadline_ticks = 0
+    body = ""
+    while deadline_ticks < 8:
+        page.wait_for_timeout(2000)
+        body = page.inner_text("body")
+        if _norm(county.pin) in _norm(body):
+            break
+        deadline_ticks += 1
+    ok, detail = _assert_parcel(body, county)
+    return Probe(ok, detail, page.url)
+
+
+# --------------------------------------------------------------------------- #
+# DURHAM -- Durham Tax CAMA (ASP.NET webforms, tabbed search). Activate the PIN
+# tab, fill the PIN textbox, click the PIN search button, assert PropertySummary.
+# --------------------------------------------------------------------------- #
+def durham_cama(page: Page, county) -> Probe:
+    page.goto(county.url, wait_until="domcontentloaded")
+    page.wait_for_timeout(2500)
+    tab = page.query_selector("a[href='#PIN']")
+    if tab:
+        tab.click()
+        page.wait_for_timeout(800)
+    inp = page.query_selector("#ctl00_ContentPlaceHolder1_PINNumberTextBox")
+    if not inp:
+        return Probe(False, "PIN search box not found -- Durham CAMA form layout changed", page.url)
+    inp.fill(county.pin)
+    page.click("#ctl00_ContentPlaceHolder1_PinButton")
+    page.wait_for_load_state("domcontentloaded")
+    page.wait_for_timeout(3000)
+    ok, detail = _assert_parcel(page.inner_text("body"), county)
+    return Probe(ok, detail, page.url)
+
+
+# --------------------------------------------------------------------------- #
+# TYLER iasWorld -- NHC etax + Lee Tax Access (same software). Accept the
+# session disclaimer (#btAgree), fill the Parcel ID box (#inpParid), submit
+# (#btSearch). A working portal returns a #searchResults row / datalet echoing
+# the PIN; a broken search mode throws "An Error has Occurred" (the Lee bug).
+# --------------------------------------------------------------------------- #
+def tyler_iasworld(page: Page, county) -> Probe:
+    page.goto(county.url, wait_until="domcontentloaded")
+    page.wait_for_timeout(2000)
+    if page.query_selector("#btAgree"):
+        page.click("#btAgree")
+        page.wait_for_load_state("domcontentloaded")
+        page.wait_for_timeout(2500)
+    inp = page.query_selector("#inpParid")
+    if not inp:
+        return Probe(False, "Parcel ID box (#inpParid) not found -- Tyler search form changed", page.url)
+    inp.fill(county.pin)
+    btn = page.query_selector("#btSearch")
+    if not btn:
+        return Probe(False, "Search button (#btSearch) not found -- Tyler search form changed", page.url)
+    btn.click()
+    page.wait_for_load_state("domcontentloaded")
+    page.wait_for_timeout(3000)
+    # The Tyler error page drops its title to "An Error has Occurred".
+    if "error has occurred" in (page.title() or "").lower():
+        return Probe(False, "result page is the Tyler error page -- search mode rejected the PIN", page.url)
+    ok, detail = _assert_parcel(page.inner_text("body"), county)
+    return Probe(ok, detail, page.url)
+
+
+ADAPTERS = {
+    "wake_imaps": wake_imaps,
+    "durham_cama": durham_cama,
+    "tyler_iasworld": tyler_iasworld,
+}

--- a/scripts/qa/verify-links/adapters.py
+++ b/scripts/qa/verify-links/adapters.py
@@ -13,7 +13,7 @@ can render a clean verdict. They only let truly unexpected exceptions bubble.
 
 from dataclasses import dataclass
 
-from playwright.sync_api import Page, TimeoutError as PWTimeout
+from playwright.sync_api import Page
 
 # Substrings (matched case-insensitively against the result body) that mean the
 # PIN search did NOT land on a real parcel -- a thrown error or an empty result.
@@ -43,15 +43,24 @@ def _norm(s: str) -> str:
 
 
 def _assert_parcel(body: str, county) -> tuple[bool, str]:
-    """Generic result check: an expected token is present and no failure marker is."""
-    low = body.lower()
-    for marker in FAILURE_MARKERS:
-        if marker in low:
-            return False, f"result page shows '{marker}' -- search form rejected the PIN"
+    """Did the result page actually show this parcel?
+
+    Success token FIRST: if the expected PIN/owner is on the page, it PASSES even
+    if some generic word like "invalid" appears elsewhere in the chrome (a footer
+    "report invalid data" link, a help tooltip). Only when NO expected token is
+    present do we scan the failure markers -- and at that point we already know
+    it's a fail, so the markers just pick the most specific reason. This ordering
+    keeps a portal changing its surrounding text from producing a false FAIL on
+    what is meant to be a trusted release gate.
+    """
     nbody = _norm(body)
     for token in county.expect_any:
         if _norm(token) in nbody:
             return True, f"parcel detail confirmed (matched {token!r})"
+    low = body.lower()
+    for marker in FAILURE_MARKERS:
+        if marker in low:
+            return False, f"result page shows '{marker}' -- search form rejected the PIN"
     return False, (
         "page loaded but the parcel detail did not show the expected PIN/owner "
         f"({', '.join(county.expect_any)}) -- the form may have silently changed"
@@ -67,7 +76,7 @@ def _click_first_visible(page: Page, texts) -> bool:
             if btn and btn.is_visible():
                 btn.click()
                 return True
-        except PWTimeout:
+        except Exception:  # noqa: BLE001 -- a bad selector on one disclaimer variant must not abort
             continue
     return False
 

--- a/scripts/qa/verify-links/counties.py
+++ b/scripts/qa/verify-links/counties.py
@@ -1,0 +1,95 @@
+"""County verify-link registry for the owner-lookup QA harness.
+
+Single source of truth, seeded directly from the owner-lookup SKILL.md
+verification-footer table and worked examples. When that table changes
+(URL, mode, or sentinel PIN), update this list and re-run the harness.
+
+Each entry pins ONE real parcel so the harness can drive the county's actual
+search form end-to-end (not just load the page) and prove a PIN round-trips.
+
+The `expected` field is the KNOWN-GOOD BASELINE. The harness compares the live
+result against it and only fails loudly when reality DIVERGES from baseline:
+  - a county that was passing now fails       -> REGRESSION (portal changed / our URL rotted)
+  - a county we know is broken now passes      -> FIXED (update this baseline + SKILL.md)
+Both mismatches exit non-zero, because both mean the SKILL.md footer and this
+file no longer agree with the live portals.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class County:
+    key: str          # canonical owner_lookup county key (matches D1 `county`)
+    name: str         # human-readable county name (for the footer prose)
+    portal_name: str  # portal label shown in the broker footer
+    url: str          # the exact URL the footer links to (resolved for deep-links)
+    pin: str          # sentinel PIN to push through the real search form
+    adapter: str      # which adapter drives this portal (see adapters.py)
+    expected: str     # known-good baseline: "pass" or "fail"
+    expected_note: str = ""  # why, if expected == "fail"
+    # Strings expected to appear on the parcel-detail result. The round-trip
+    # passes only if at least one is found (alphanumeric-normalized substring
+    # match) AND no failure marker is present. Keep tolerant.
+    expect_any: tuple = field(default_factory=tuple)
+
+
+# Order mirrors the SKILL.md table: WAKE, DURHAM, NEW_HANOVER, LEE.
+COUNTIES = [
+    County(
+        key="WAKE",
+        name="Wake",
+        portal_name="Wake iMaps",
+        url="https://maps.raleighnc.gov/imaps/?pin=0734835370",
+        pin="0734835370",
+        adapter="wake_imaps",
+        expected="pass",
+        # 0734835370 == 100 Connemara Dr, Cary (SKILL.md Example 1).
+        expect_any=("0734835370", "PNC OF NORTH CAROLINA", "CONNEMARA"),
+    ),
+    County(
+        key="DURHAM",
+        name="Durham",
+        portal_name="Durham Tax CAMA",
+        url="https://taxcama.dconc.gov/camapwa/#PIN",
+        pin="0822419440",
+        adapter="durham_cama",
+        expected="pass",
+        # Resolves to 1500 W Main St -> DUKE UNIVERSITY. Page shows "0822-41-9440".
+        expect_any=("0822419440", "DUKE UNIVERSITY"),
+    ),
+    County(
+        key="NEW_HANOVER",
+        name="New Hanover",
+        portal_name="NHC etax",
+        url="https://etax.nhcgov.com/PT/search/commonsearch.aspx?mode=parid",
+        pin="R04720-007-011-000",
+        adapter="tyler_iasworld",
+        expected="pass",
+        # Tyler echoes the PIN in the result row; dashes are normalized away.
+        expect_any=("R04720007011000", "R04720"),
+    ),
+    County(
+        key="LEE",
+        name="Lee",
+        portal_name="Lee County Tax Access",
+        url="https://taxaccess.leecountync.gov/pt/search/commonsearch.aspx?mode=parid",
+        pin="9645-45-9484-00",
+        adapter="tyler_iasworld",
+        expected="fail",
+        expected_note=(
+            "Known bug (gi-plugins #18 / lee-and-associates #18): Tyler iasWorld "
+            "rejects mode=parid on submit ('An Error has Occurred'). The page LOADS "
+            "but the PIN search throws. Flip to 'pass' once the sibling fix changes "
+            "the SKILL.md footer to the working search mode (mode=realprop)."
+        ),
+        expect_any=("9645459484", "9645-45-9484-00"),
+    ),
+]
+
+
+def by_key(key: str) -> County:
+    for c in COUNTIES:
+        if c.key == key.upper():
+            return c
+    raise KeyError(f"No county with key {key!r}. Known: {[c.key for c in COUNTIES]}")

--- a/scripts/qa/verify-links/requirements.txt
+++ b/scripts/qa/verify-links/requirements.txt
@@ -1,0 +1,5 @@
+# owner-lookup verify-link QA harness
+# Browser automation only -- this is OFFLINE pre-release QA tooling, never on the
+# broker request path (gotcha G2). After installing, fetch the browser binary:
+#   python3 -m playwright install chromium
+playwright>=1.40,<2

--- a/scripts/qa/verify-links/test_verify_links.py
+++ b/scripts/qa/verify-links/test_verify_links.py
@@ -61,6 +61,18 @@ def test_assert_parcel_fails_when_pin_absent():
     assert "did not show" in detail
 
 
+def test_assert_parcel_success_token_beats_generic_failure_word():
+    # The correct parcel IS shown, but the page chrome contains a generic word
+    # from FAILURE_MARKERS ("invalid"). Token-first ordering must still PASS --
+    # otherwise a footer/help-text change would false-FAIL the release gate.
+    body = (
+        "Parcel R04720-007-011-000 — OWNER: ACME HOLDINGS LLC\n"
+        "Footer: to report invalid assessment data, contact the county."
+    )
+    ok, detail = _assert_parcel(body, _c("R04720007011000"))
+    assert ok is True, detail
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     for t in tests:

--- a/scripts/qa/verify-links/test_verify_links.py
+++ b/scripts/qa/verify-links/test_verify_links.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Offline unit tests for the verify-link QA harness decision logic.
+
+No network, no browser -- covers the pure parts most likely to be edited later:
+baseline verdicts, PIN normalization, and result-page assertion (success, the
+Tyler error page, dash-formatted PINs, empty results). Run:
+
+    python3 test_verify_links.py        # prints OK or fails loudly
+"""
+
+from types import SimpleNamespace
+
+from adapters import _assert_parcel, _norm
+from verify_links import _verdict
+
+
+def _c(*expect):
+    return SimpleNamespace(expect_any=tuple(expect))
+
+
+def test_norm_strips_dashes_and_spaces():
+    assert _norm("0822-41-9440") == "0822419440"
+    assert _norm("R04720-007-011-000") == "R04720007011000"
+    assert _norm(" pnc llc ") == "PNCLLC"
+
+
+def test_verdict_baseline_matrix():
+    # (actual_pass, expected) -> ok_with_baseline
+    assert _verdict(True, "pass")[0] is True          # healthy
+    assert _verdict(False, "fail")[0] is True          # known-broken, steady (Lee today)
+    assert _verdict(False, "pass")[0] is False         # REGRESSION -> loud
+    assert _verdict(True, "fail")[0] is False          # FIXED -> loud (update baseline)
+    assert "REGRESSION" in _verdict(False, "pass")[1]
+    assert "FIXED" in _verdict(True, "fail")[1]
+
+
+def test_assert_parcel_success_with_dash_formatted_pin():
+    body = "Property Summary\nPIN # 0822-41-9440\nProperty Owner DUKE UNIVERSITY"
+    ok, detail = _assert_parcel(body, _c("0822419440", "DUKE UNIVERSITY"))
+    assert ok is True, detail
+
+
+def test_assert_parcel_catches_tyler_error_page():
+    body = "An Error has Occurred\nThe system encountered a problem and cannot complete the requested action."
+    ok, detail = _assert_parcel(body, _c("9645459484"))
+    assert ok is False
+    assert "rejected the PIN" in detail
+
+
+def test_assert_parcel_catches_empty_results():
+    body = "Search by Parcel ID\nNo records found for your search."
+    ok, detail = _assert_parcel(body, _c("0734835370"))
+    assert ok is False
+
+
+def test_assert_parcel_fails_when_pin_absent():
+    # Page loaded, no failure marker, but the expected parcel isn't shown.
+    body = "Welcome to the property search portal. Please enter a parcel id."
+    ok, detail = _assert_parcel(body, _c("0734835370", "PNC OF NORTH CAROLINA"))
+    assert ok is False
+    assert "did not show" in detail
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"\n{len(tests)} passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qa/verify-links/verify_links.py
+++ b/scripts/qa/verify-links/verify_links.py
@@ -99,10 +99,18 @@ def run(counties, *, headed: bool, out: Path, screenshots: bool):
             # from baseline is the thing we act on (regression or fix), so confirm
             # it with one retry before trusting it -- avoids a network blip blocking
             # a release. A result that already matches baseline is left as-is.
-            if not _matches_baseline(probe, error, c):
+            flaky = False
+            first_matched = _matches_baseline(probe, error, c)
+            if not first_matched:
                 print(f"[{c.key}] diverged from baseline; retrying once to rule out a transient hiccup...")
                 probe, error, shot = _drive(browser, c, out=out, screenshots=screenshots)
-            rows.append({"county": c, "probe": probe, "error": error, "shot": shot})
+                # The two attempts DISAGREED -> the portal is unstable. Never let a
+                # retry silently overwrite the divergence: flag it so a flap-to-green
+                # (a real intermittent break masked as a pass) is visible, not swallowed.
+                if _matches_baseline(probe, error, c) != first_matched:
+                    flaky = True
+                    print(f"[{c.key}] WARNING: result flapped across two attempts -- portal is unstable")
+            rows.append({"county": c, "probe": probe, "error": error, "shot": shot, "flaky": flaky})
         browser.close()
     return rows
 
@@ -121,9 +129,12 @@ def render(rows, *, out: Path):
     ]
     all_ok = True
     had_harness_error = False
+    had_flaky = False
     details = []
     for r in rows:
         c, probe, error = r["county"], r["probe"], r["error"]
+        flaky = r.get("flaky", False)
+        flaky_tag = " ⚠️ FLAPPED" if flaky else ""
         if error is not None:
             had_harness_error = True
             result_cell, ok, label = "⚠️ ERROR", False, "harness error driving portal"
@@ -133,10 +144,15 @@ def render(rows, *, out: Path):
             ok, label = _verdict(actual_pass, c.expected)
             result_cell = "✅ PASS" if actual_pass else "❌ FAIL"
             note = f"  ({c.expected_note})" if (c.expected == "fail" and c.expected_note) else ""
-            details.append(f"- **{c.name}** {result_cell}: {probe.detail}{note}")
+            flaky_note = (
+                "  ⚠️ UNSTABLE: the two attempts disagreed; this verdict is the *retry* and "
+                "should not be trusted as steady — re-run to confirm." if flaky else ""
+            )
+            details.append(f"- **{c.name}** {result_cell}: {probe.detail}{note}{flaky_note}")
+        had_flaky = had_flaky or flaky
         all_ok = all_ok and ok
         baseline_cell = c.expected + (" (known #18)" if c.expected == "fail" else "")
-        verdict_cell = ("✓ " if ok else "🔴 ") + label
+        verdict_cell = ("✓ " if ok else "🔴 ") + label + flaky_tag
         lines.append(
             f"| {c.name} | {c.portal_name} | `{c.pin}` | {result_cell} | {baseline_cell} | {verdict_cell} |"
         )
@@ -144,6 +160,10 @@ def render(rows, *, out: Path):
     matched = sum(1 for r in rows if r["error"] is None and _verdict(r["probe"].found, r["county"].expected)[0])
     total = len(rows)
     lines.append(f"**Summary:** {matched}/{total} counties match baseline.")
+    if had_flaky:
+        lines.append("⚠️ **One or more counties FLAPPED** (the two attempts disagreed). A retry that "
+                     "flips a divergence to green can mask an intermittently-broken portal — treat any "
+                     "flapped county as unconfirmed and re-run before relying on this as a release gate.")
     if all_ok and not had_harness_error:
         lines.append("All portals behave as expected. No broker-facing regression.")
     else:

--- a/scripts/qa/verify-links/verify_links.py
+++ b/scripts/qa/verify-links/verify_links.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""owner-lookup verify-link QA harness.
+
+Drives each county verification portal that the owner-lookup skill links brokers
+to, pushes that county's sentinel PIN through the REAL search form, and asserts
+the result page actually shows the parcel -- catching a broken search mode or a
+changed form BEFORE a broker hits it mid-deal.
+
+Why a browser and not curl: every one of these portals returns HTTP 200 on the
+search page even when the search itself is broken (the Lee mode=parid bug is the
+poster child -- the form loads, then throws on submit). Tyler iasWorld also
+gates behind a click-through disclaimer that sets a session cookie. Only a real
+browser submit exercises what the broker actually experiences.
+
+Baseline-aware: each county's known-good state lives in counties.py. The harness
+exits non-zero only when LIVE state diverges from baseline -- a regression (was
+passing, now fails) or an unexpected fix (known-broken, now passes -> time to
+update the baseline + the SKILL.md footer). A steady known-broken county (Lee
+today) is reported but does NOT fail the run, so this can gate releases without
+being blocked by a separately-tracked bug.
+
+Usage:
+  python3 verify_links.py                     # all counties, headless, writes report + screenshots to ./out
+  python3 verify_links.py --county LEE         # one county
+  python3 verify_links.py --headed             # watch it drive the portals
+  python3 verify_links.py --out /tmp/qa        # custom output dir
+  python3 verify_links.py --no-screenshots     # skip screenshots (faster)
+
+Exit code 0 = live state matches baseline for every county checked.
+Exit code 1 = at least one county diverged from baseline (regression or fix).
+Exit code 2 = a harness/automation error (unexpected exception driving a portal).
+"""
+
+import argparse
+import datetime
+import sys
+import traceback
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+from adapters import ADAPTERS
+from counties import COUNTIES, by_key
+
+HERE = Path(__file__).resolve().parent
+
+
+def _verdict(actual_pass: bool, expected: str):
+    """Return (ok_with_baseline, label) comparing live result to known baseline."""
+    expected_pass = expected == "pass"
+    if actual_pass and expected_pass:
+        return True, "OK"
+    if not actual_pass and not expected_pass:
+        return True, "OK (known-broken)"
+    if actual_pass and not expected_pass:
+        return False, "FIXED -> update baseline + SKILL.md footer"
+    return False, "REGRESSION -> portal/search changed; brokers are now blocked"
+
+
+def _drive(browser, c, *, out: Path, screenshots: bool):
+    """Run one county's adapter once in a fresh context. Returns (probe, error, shot)."""
+    # Fresh context so the disclaimer / session-cookie step is genuinely exercised
+    # every run (not cached from a prior county).
+    ctx = browser.new_context(viewport={"width": 1400, "height": 1000})
+    page = ctx.new_page()
+    page.set_default_timeout(45000)
+    shot = ""
+    try:
+        probe = ADAPTERS[c.adapter](page, c)
+        error = None
+    except Exception as exc:  # noqa: BLE001 -- harness must survive one bad portal
+        probe = None
+        error = f"{type(exc).__name__}: {exc}"
+        traceback.print_exc()
+    if screenshots:
+        shot = str(out / f"{c.key.lower()}.png")
+        try:
+            page.screenshot(path=shot, full_page=False)
+        except Exception:  # noqa: BLE001
+            shot = ""
+    ctx.close()
+    return probe, error, shot
+
+
+def _matches_baseline(probe, error, c) -> bool:
+    if error is not None or probe is None:
+        return False
+    return _verdict(probe.found, c.expected)[0]
+
+
+def run(counties, *, headed: bool, out: Path, screenshots: bool):
+    out.mkdir(parents=True, exist_ok=True)
+    rows = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=not headed)
+        for c in counties:
+            probe, error, shot = _drive(browser, c, out=out, screenshots=screenshots)
+            # These are live, occasionally-flaky government portals. A divergence
+            # from baseline is the thing we act on (regression or fix), so confirm
+            # it with one retry before trusting it -- avoids a network blip blocking
+            # a release. A result that already matches baseline is left as-is.
+            if not _matches_baseline(probe, error, c):
+                print(f"[{c.key}] diverged from baseline; retrying once to rule out a transient hiccup...")
+                probe, error, shot = _drive(browser, c, out=out, screenshots=screenshots)
+            rows.append({"county": c, "probe": probe, "error": error, "shot": shot})
+        browser.close()
+    return rows
+
+
+def render(rows, *, out: Path):
+    now = datetime.datetime.now().astimezone()
+    stamp = now.strftime("%Y-%m-%d %H:%M %Z")
+    lines = [
+        f"# Owner-Lookup Verify-Link QA — {stamp}",
+        "",
+        "Drives each county verify-footer portal and pushes the sentinel PIN through",
+        "the real search form. PASS = the result page showed that parcel.",
+        "",
+        "| County | Portal | Sentinel PIN | Result | Baseline | Verdict |",
+        "|---|---|---|---|---|---|",
+    ]
+    all_ok = True
+    had_harness_error = False
+    details = []
+    for r in rows:
+        c, probe, error = r["county"], r["probe"], r["error"]
+        if error is not None:
+            had_harness_error = True
+            result_cell, ok, label = "⚠️ ERROR", False, "harness error driving portal"
+            details.append(f"- **{c.name}** ⚠️ harness error: {error}")
+        else:
+            actual_pass = probe.found
+            ok, label = _verdict(actual_pass, c.expected)
+            result_cell = "✅ PASS" if actual_pass else "❌ FAIL"
+            note = f"  ({c.expected_note})" if (c.expected == "fail" and c.expected_note) else ""
+            details.append(f"- **{c.name}** {result_cell}: {probe.detail}{note}")
+        all_ok = all_ok and ok
+        baseline_cell = c.expected + (" (known #18)" if c.expected == "fail" else "")
+        verdict_cell = ("✓ " if ok else "🔴 ") + label
+        lines.append(
+            f"| {c.name} | {c.portal_name} | `{c.pin}` | {result_cell} | {baseline_cell} | {verdict_cell} |"
+        )
+    lines += ["", "## Detail", *details, ""]
+    matched = sum(1 for r in rows if r["error"] is None and _verdict(r["probe"].found, r["county"].expected)[0])
+    total = len(rows)
+    lines.append(f"**Summary:** {matched}/{total} counties match baseline.")
+    if all_ok and not had_harness_error:
+        lines.append("All portals behave as expected. No broker-facing regression.")
+    else:
+        lines.append("⚠️ At least one county diverged from baseline — see verdicts above. "
+                     "If a known-broken county now PASSES, flip its `expected` in counties.py "
+                     "and update the SKILL.md footer. If a passing county now FAILS, the portal "
+                     "or our linked URL changed and brokers are blocked — fix before release.")
+    report = "\n".join(lines) + "\n"
+    (out / "report.md").write_text(report)
+    return report, all_ok, had_harness_error
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="owner-lookup verify-link QA harness")
+    ap.add_argument("--county", help="run a single county by key (e.g. LEE)", default=None)
+    ap.add_argument("--headed", action="store_true", help="show the browser")
+    ap.add_argument("--out", default=str(HERE / "out"), help="output dir for report + screenshots")
+    ap.add_argument("--no-screenshots", dest="screenshots", action="store_false", help="skip screenshots")
+    args = ap.parse_args(argv)
+
+    counties = [by_key(args.county)] if args.county else COUNTIES
+    out = Path(args.out)
+    rows = run(counties, headed=args.headed, out=out, screenshots=args.screenshots)
+    report, all_ok, had_harness_error = render(rows, out=out)
+    print(report)
+    print(f"(report + screenshots written to {out})")
+    if had_harness_error:
+        return 2
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed
Adds an offline, browser-driven QA harness that pushes each county's sentinel PIN through the **real** owner-lookup verify-footer search form and asserts the parcel comes back — catching a broken search mode that a load-only (HTTP 200) check passes right over. Had it existed, it would have caught the Lee `mode=parid` bug (#18).

Lives at `scripts/qa/verify-links/`. Not wired into the broker request path — offline pre-release tooling only (gotcha G2).

### Current state (this run)
| County | Result | Baseline |
|---|---|---|
| Wake (iMaps deep-link) | ✅ PASS | pass |
| Durham (Tax CAMA) | ✅ PASS | pass |
| New Hanover (Tyler iasWorld) | ✅ PASS | pass — was "TBD" in the issue, now confirmed |
| Lee (Tyler iasWorld) | ❌ FAIL | **fail (known #18)** — `mode=parid` throws on submit |

4/4 match baseline → exit 0. The harness is **baseline-aware**: it exits non-zero only when live state *diverges* from `counties.py` (a regression, or an unexpected fix that should flip a baseline), with one auto-retry to absorb flaky-portal blips. A steady known-broken county (Lee) is reported but does not block a release.

### Follow-ups (not in this PR)
- When #18 lands and the SKILL.md footer flips Lee to a working search mode, set Lee's `expected` to `pass` in `counties.py`.
- Optional: reference this harness as a Stage 3a step in the parent-repo plugin-development-process doc.

## Checklist
- [x] Linked to issue (`Closes #19`)
- [x] Version bump needed? **N** — chore, no broker behavior change; bundles into the next release
- [x] CHANGELOG.md updated if broker-visible — **N/A**, internal QA tooling, not broker-visible
- [x] skill-contract-check passed (gi-plugins only) — **N/A**, adds no skill / touches no SKILL.md
- [x] verification-before-completion run — modules compile, offline tests 6/6, live full run + simulated-regression exit-code check
- [x] Worktree cleanup planned for after merge (`superpowers:finishing-a-development-branch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)