### PR TITLE
fix(owner-lookup): Lee verify link mode=realprop, not parid (Closes #18)

### DIFF
--- a/plugins/lee-internal-comps/skills/owner-lookup/SKILL.md
+++ b/plugins/lee-internal-comps/skills/owner-lookup/SKILL.md
@@ -81,7 +81,7 @@ These were verified via Chrome DevTools on 2026-05-23 with the sentinel PINs and
 | **WAKE** | Wake iMaps | `https://maps.raleighnc.gov/imaps/?pin={PIN}` | **Direct deep-link.** Opens iMaps with the parcel pre-selected; the broker accepts a one-time disclaimer and lands on the parcel's full Info pane (owner, mail, valuation, last sale, building). |
 | **DURHAM** | Durham Tax CAMA | `https://taxcama.dconc.gov/camapwa/#PIN` | Opens Durham's CAMA portal with the PIN search tab already expanded. Broker pastes the 10-digit PIN and clicks search. |
 | **NEW_HANOVER** | NHC etax | `https://etax.nhcgov.com/PT/search/commonsearch.aspx?mode=parid` | Tyler iasWorld. After accepting the disclaimer (once per session), opens the Parcel ID search form. Broker pastes the PIN and clicks Search. |
-| **LEE** | Lee County Tax Access | `https://taxaccess.leecountync.gov/pt/search/commonsearch.aspx?mode=parid` | Same Tyler iasWorld pattern as NHC. Opens the Parcel search form; broker pastes the PIN and clicks Search. |
+| **LEE** | Lee County Tax Access | `https://taxaccess.leecountync.gov/pt/search/commonsearch.aspx?mode=realprop` | Tyler iasWorld, like NHC — but Lee's working entry point is the Real Estate Property search (`mode=realprop`), **not** `mode=parid`, which throws an error page on this county's instance. Accept the disclaimer, paste the PIN, click Search. |
 
 ### Worked examples of the verification footer (copy this format exactly)
 
@@ -95,7 +95,7 @@ These were verified via Chrome DevTools on 2026-05-23 with the sentinel PINs and
 > Heads-up on freshness: this is from our bulk-staged copy of New Hanover County's GIS, refreshed roughly quarterly — not live. For anything time-sensitive (offer letters, deed work), verify against **[NHC etax](https://etax.nhcgov.com/PT/search/commonsearch.aspx?mode=parid)** — search by PIN: `R04720-007-011-000`.
 
 **Lee** (parcel `9645-45-9484-00`):
-> Heads-up on freshness: this is from our bulk-staged copy of Lee County's GIS, refreshed roughly quarterly — not live. For anything time-sensitive (offer letters, deed work), verify against **[Lee County Tax Access](https://taxaccess.leecountync.gov/pt/search/commonsearch.aspx?mode=parid)** — search by PIN: `9645-45-9484-00`.
+> Heads-up on freshness: this is from our bulk-staged copy of Lee County's GIS, refreshed roughly quarterly — not live. For anything time-sensitive (offer letters, deed work), verify against **[Lee County Tax Access](https://taxaccess.leecountync.gov/pt/search/commonsearch.aspx?mode=realprop)** — search by PIN: `9645-45-9484-00`.
 
 **Do NOT** ship the response without this footer, ever. **Do NOT** use a generic Wake-only link when the parcel is in Durham, NHC, or Lee.
 

--- a/scripts/qa/verify-links/README.md
+++ b/scripts/qa/verify-links/README.md
@@ -13,10 +13,12 @@ through each portal's **actual search form** and asserts the parcel comes back.
 
 Every one of these portals returns **HTTP 200 on the search page even when the
 search itself is broken**. A load-only check (`curl … | grep 200`) passes on all
-four — including Lee, where the form loads fine and then throws `An Error has
-Occurred` the moment you submit a PIN (the bug in gi-plugins #18 / lee-and-associates
-#18). Tyler iasWorld portals also gate behind a click-through disclaimer that sets a
-session cookie. Only a real browser submit reproduces what the broker experiences.
+four — the motivating example was Lee, whose form loaded fine and then threw `An
+Error has Occurred` the moment you submitted a PIN, because the footer linked the
+wrong Tyler search mode (`mode=parid`); this harness caught it and gi-plugins #18
+fixed it to `mode=realprop`. Tyler iasWorld portals also gate behind a click-through
+disclaimer that sets a session cookie. Only a real browser submit reproduces what the
+broker experiences.
 
 ## What it checks
 
@@ -43,10 +45,11 @@ resolves the PIN. A Wake regression in pane resolution is caught; there is no se
 | Wake | ✅ PASS | pass | `100 CONNEMARA DR` / PNC OF NORTH CAROLINA LLC renders in the info pane |
 | Durham | ✅ PASS | pass | resolves to `PropertySummary.aspx?PIN=0822419440` (DUKE UNIVERSITY) |
 | New Hanover | ✅ PASS | pass | results row echoes `R04720-007-011-000` |
-| Lee | ❌ FAIL | **fail (known #18)** | `mode=parid` throws `An Error has Occurred` on submit. Expected-broken until the sibling fix flips the footer to a working search mode (`mode=realprop`). |
+| Lee | ✅ PASS | pass | `mode=realprop` lands on the Real Estate Property search and returns the parcel. (`mode=parid` threw `An Error has Occurred` — that was gi-plugins #18, now fixed; the footer + this baseline use `realprop`.) |
 
-4/4 match baseline → exit 0. Had this harness existed, it would have caught the Lee
-bug. NHC was "TBD" in the issue; this run confirms it **passes**.
+4/4 match baseline → exit 0. This harness caught the Lee `mode=parid` bug (#18) that a
+load-only check passed; #18's fix flipped Lee to `realprop` and this baseline with it.
+NHC was "TBD" in the issue; this run confirms it **passes**.
 
 ## Run it
 
@@ -76,12 +79,13 @@ only fails loudly (exit 1) when **live state diverges from baseline**:
 - **A passing county now FAILS → `REGRESSION`.** The portal or our linked URL
   changed; brokers are blocked. Fix the SKILL.md footer (and `counties.py`) before
   the next release.
-- **A known-broken county now PASSES → `FIXED`.** The bug got fixed elsewhere (e.g.
-  Lee #18 lands). Flip that county's `expected` to `pass` in `counties.py` and update
-  the SKILL.md footer to the now-working URL.
+- **A known-broken county now PASSES → `FIXED`.** The bug got fixed elsewhere (this is
+  exactly what happened to Lee via #18). Flip that county's `expected` to `pass` in
+  `counties.py` and update the SKILL.md footer to the now-working URL.
 
-A *steady* known-broken county (Lee today) is reported but does **not** fail the run,
-so this can gate releases without being permanently blocked by a separately-tracked
+A *steady* known-broken county (none today — all four pass) is reported but does
+**not** fail the run, so this can gate releases without being permanently blocked by a
+separately-tracked
 bug. Divergences are retried once automatically to absorb a flaky-portal blip before
 they're trusted.
 

--- a/scripts/qa/verify-links/counties.py
+++ b/scripts/qa/verify-links/counties.py
@@ -73,16 +73,13 @@ COUNTIES = [
         key="LEE",
         name="Lee",
         portal_name="Lee County Tax Access",
-        url="https://taxaccess.leecountync.gov/pt/search/commonsearch.aspx?mode=parid",
+        # mode=realprop is Lee's working entry point. mode=parid throws an error
+        # page on this county's Tyler instance (was gi-plugins #18, fixed). Keep
+        # this URL identical to the SKILL.md footer for Lee.
+        url="https://taxaccess.leecountync.gov/pt/search/commonsearch.aspx?mode=realprop",
         pin="9645-45-9484-00",
         adapter="tyler_iasworld",
-        expected="fail",
-        expected_note=(
-            "Known bug (gi-plugins #18 / lee-and-associates #18): Tyler iasWorld "
-            "rejects mode=parid on submit ('An Error has Occurred'). The page LOADS "
-            "but the PIN search throws. Flip to 'pass' once the sibling fix changes "
-            "the SKILL.md footer to the working search mode (mode=realprop)."
-        ),
+        expected="pass",
         expect_any=("9645459484", "9645-45-9484-00"),
     ),
 ]

--- a/scripts/qa/verify-links/test_verify_links.py
+++ b/scripts/qa/verify-links/test_verify_links.py
@@ -27,7 +27,7 @@ def test_norm_strips_dashes_and_spaces():
 def test_verdict_baseline_matrix():
     # (actual_pass, expected) -> ok_with_baseline
     assert _verdict(True, "pass")[0] is True          # healthy
-    assert _verdict(False, "fail")[0] is True          # known-broken, steady (Lee today)
+    assert _verdict(False, "fail")[0] is True          # known-broken, steady (none today)
     assert _verdict(False, "pass")[0] is False         # REGRESSION -> loud
     assert _verdict(True, "fail")[0] is False          # FIXED -> loud (update baseline)
     assert "REGRESSION" in _verdict(False, "pass")[1]


### PR DESCRIPTION
Re-lands #42 (auto-closed when #40's base branch was deleted on merge), branched fresh off main so it carries the hardened harness and does NOT revert #39. Lee footer parid->realprop (NHC untouched); QA baseline flipped to match. Full harness 4/4 PASS, offline tests 7/7, live-verified Lee on realprop. Independent review of this change already completed on #42 (no Critical/Important findings against the Lee fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)