### PR TITLE
external lease comps size on the space leased, not the building (1.34.0; sibling of lee#469)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lee-internal-comps",
       "source": "./plugins/lee-internal-comps",
       "description": "Lee & Associates broker toolkit. Comps (Lee internal and external, lease and sale) as Excel + Lee-branded PDF; demographic and business-key-facts reports; owner, parcel, and mailing-list lookups; traffic counts, labor shed, drive times (reach maps + drive times to named destinations), site infrastructure, development pipeline, and tenants in the market; comp maps and area-amenities map kits; a guided flyer brief; and Lee branding for anything you build. Ask in plain English or use /comps, /internal-comps, /demographic-summary, /owner-lookup and the rest.",
-      "version": "1.33.0"
+      "version": "1.34.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Brokers pick up releases by syncing the marketplace in Cowork (auto-sync toggle 
 via `/plugin update`. `marketplace.json` and `plugins/lee-internal-comps/.claude-plugin/plugin.json`
 carry the same version as of 1.4.0.
 
+## [1.34.0] - 2026-08-21
+
+### Fixed
+
+- **External lease comps size on the space leased, not the building** (Worker
+  0.43.0, lee-and-associates#469, closes lee-and-associates#180 / the
+  gi-plugins#105 interim): a broker's lease size range used to go out as
+  `min/max_building_sf`, and `building_sf` (the building footprint) is empty on
+  most external lease rows, so any size-bounded external lease search returned
+  ~0 (Christian Sommer's Apex 2,000–20,000 SF ask on 2026-08-21). The Worker now
+  carries `leased_sf` (the external platform's "Size Leased SF", promoted and
+  backfilled) and `search_external_lease_comps` takes `min/max_leased_sf`;
+  `external-comps` sends the lease size range there (sales still filter
+  `building_sf`), and every lease size surface (Excel column, Summary stats,
+  chat table, ranking) reads `leased_sf`. `internal-and-external-comps` retires
+  the #105 blank: external lease rows show their real "Leased SF", never the
+  building size, blank only when the row has no leased size.
+
 ## [1.33.0] - 2026-08-20
 
 ### Added

--- a/plugins/lee-internal-comps/.claude-plugin/plugin.json
+++ b/plugins/lee-internal-comps/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lee-internal-comps",
   "description": "Lee & Associates broker toolkit. Comps (Lee internal and external, lease and sale) as Excel + Lee-branded PDF; demographic and business-key-facts reports; owner, parcel, and mailing-list lookups; traffic counts, labor shed, drive times (reach maps + drive times to named destinations), site infrastructure, development pipeline, and tenants in the market; comp maps and area-amenities map kits; a guided flyer brief; and Lee branding for anything you build. Ask in plain English or use /comps, /internal-comps, /demographic-summary, /owner-lookup and the rest.",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "author": {
     "name": "Grounded Intelligence"
   },

--- a/plugins/lee-internal-comps/skills/external-comps/SKILL.md
+++ b/plugins/lee-internal-comps/skills/external-comps/SKILL.md
@@ -88,6 +88,9 @@ covers: it tells you **why** nothing matched, so the broker is never left with s
 - `location_only_rows` — only present when **nothing** binds alone (two or more filters would
   have to loosen together); it is how many comps exist in the requested city / zip at all.
 - `note` — a one-sentence plain-English version of the above.
+- The example above is a **sale**; on a **lease** the size filter is named `min_leased_sf` /
+  `max_leased_sf` (the space leased), so tell the broker "the leased size range" cut the
+  candidates, never "the building size" (lee#469).
 
 **How to reply (after the freshness line):**
 
@@ -119,7 +122,7 @@ The dict you pass to `validate_request`. `asset_type` and `transaction_type` are
 | `asset_type` | yes | `"industrial"` \| `"office"` \| `"retail"` \| `"flex"` \| `"medical"` \| `"multifamily"` \| `"student"` \| `"land"` \| `"hospitality"` \| `"health_care"` \| `"specialty"` |
 | `transaction_type` | yes | `"lease"` \| `"sale"` |
 | `geography` | no | `{"named_market": str}` or `{"cities": [str, ...]}` |
-| `size_range` | no | `{"min_sf": int, "max_sf": int}` |
+| `size_range` | no | `{"min_sf": int, "max_sf": int}` — building SF for a sale, **leased** SF for a lease (the space the tenant took). |
 | `date_window` | no | `{"lookback_months": int}` or `{"from": "YYYY-MM-DD", "to": "YYYY-MM-DD"}` |
 | `target_count` | no | int (default 8) |
 | `min_sale_price` | no | int — sale only |
@@ -174,7 +177,7 @@ Response: `{"rows": [...], "freshness": "..."}` with all typed sale columns plus
 | `city`, `state`, `zip` | str | same as sale. |
 | `property_type` | str | source-platform taxonomy. |
 | `min_lease_start_date` / `max_lease_start_date` | str (ISO) | inclusive. |
-| `min_building_sf` / `max_building_sf` | int | inclusive. |
+| `min_leased_sf` / `max_leased_sf` | int | inclusive. The space the tenant **leased** (`leased_sf`) — this is what a broker's size range means for a lease comp. `build_mcp_params` maps `size_range` here for leases. Never send a lease size range as `min/max_building_sf`: `building_sf` is the building footprint and is empty on most external lease rows, so that filter returns ~0 (lee#469). The Worker still accepts the old names as aliases for `leased_sf`. |
 | `min_base_rent` / `max_base_rent` | float | $/SF/yr. |
 | `min_lease_term_months` / `max_lease_term_months` | int | inclusive. |
 | `tenant_industry` | str | exact match. |
@@ -255,7 +258,7 @@ The model does not need to memorize the column list, but for ranking and the Mar
 
 **Sale (`search_external_sale_comps`):** `external_id`, `property_address`, `property_city`, `property_state`, `property_zip`, `county`, `submarket`, `market`, `external_property_id`, `external_property_url`, `property_type`, `property_secondary_type`, `building_sf`, `year_built`, `sale_price`, `price_per_sf`, `sale_date`, `actual_cap_rate`, `noi`, `percent_leased`, `sale_type`, `sale_conditions`, `days_on_market`, `sale_notes`, `buyer_true_company`, `seller_true_company`, `buyers_broker_company`, `listing_broker_company`, ...
 
-**Lease (`search_external_lease_comps`):** `external_id`, `property_address`, `property_city`, `property_state`, `property_zip`, `county`, `submarket`, `market`, `external_property_id`, `property_type`, `building_sf`, `lease_start_date`, `lease_term_months`, `lease_expiration_date`, `base_rent`, `rent_type`, `escalations`, `free_rent_months`, `ti_allowance`, `tenant_name`, `tenant_industry`, `floor`, `suite`, `space_type`, ...
+**Lease (`search_external_lease_comps`):** `external_id`, `property_address`, `property_city`, `property_state`, `property_zip`, `county`, `submarket`, `market`, `external_property_id`, `property_type`, `leased_sf` (the leased premises — the lease comp's size; use it for the SF column, ranking, and size stats), `building_sf` (the building footprint, often empty), `lease_start_date`, `lease_term_months`, `lease_expiration_date`, `base_rent`, `rent_type`, `escalations`, `free_rent_months`, `ti_allowance`, `tenant_name`, `tenant_industry`, `floor`, `suite`, `space_type`, ...
 
 Both shapes also include `raw_fields_json` — a stringified JSON blob of unpromoted external columns. Don't surface it directly to the broker; use `get_external_comp_detail` to inspect a specific row's full record.
 

--- a/plugins/lee-internal-comps/skills/external-comps/helpers.py
+++ b/plugins/lee-internal-comps/skills/external-comps/helpers.py
@@ -137,9 +137,11 @@ DISPLAY_COLUMNS_SALE = [
     "external_property_url", "sale_notes",
 ]
 
+# leased_sf = the space the tenant took (the external platform's "Size Leased SF",
+# promoted lee#469); building_sf is the footprint and is NULL on most lease rows.
 DISPLAY_COLUMNS_LEASE = [
     "external_id", "property_address", "property_city", "county", "submarket",
-    "property_type", "building_sf", "lease_start_date", "lease_term_months",
+    "property_type", "leased_sf", "building_sf", "lease_start_date", "lease_term_months",
     "lease_expiration_date", "base_rent", "rent_type", "escalations",
     "free_rent_months", "ti_allowance", "tenant_name", "tenant_industry",
     "floor", "suite", "space_type", "external_property_url",
@@ -275,10 +277,14 @@ def build_mcp_params(validated: dict) -> dict:
 
     if validated.get("size_range"):
         sr = validated["size_range"]
+        # A broker's size range means the building for a sale and the SPACE
+        # LEASED for a lease (lee#469: sending a lease range as building_sf
+        # returned ~0 because building_sf is NULL on most external lease rows).
+        size_key = "building_sf" if tx == "sale" else "leased_sf"
         if "min_sf" in sr:
-            base["min_building_sf"] = int(sr["min_sf"])
+            base[f"min_{size_key}"] = int(sr["min_sf"])
         if "max_sf" in sr:
-            base["max_building_sf"] = int(sr["max_sf"])
+            base[f"max_{size_key}"] = int(sr["max_sf"])
 
     # --- Transaction-type specific filters ---
     if tx == "sale":
@@ -458,11 +464,12 @@ def rank_comps(
 
     # --- Score the main set ---
     date_key = "sale_date" if tx == "sale" else "lease_start_date"
+    size_key = "building_sf" if tx == "sale" else "leased_sf"
 
     def score(r: dict) -> float:
         recency = _months_since(r.get(date_key))
-        if target_size and r.get("building_sf"):
-            size_prox = abs(float(r["building_sf"]) - target_size)
+        if target_size and r.get(size_key):
+            size_prox = abs(float(r[size_key]) - target_size)
         else:
             size_prox = 0.0  # no target → skip the term
         # Geo score: core RDU submarkets get 0; edge gets 1.
@@ -602,8 +609,9 @@ def format_excel(
     # stats keeps "Median $/SF: $0.00" off broker-facing workbooks. Count stays len(rows).
     rate_vals = [r.get(rate_col) for r in rows
                  if isinstance(r.get(rate_col), (int, float)) and r.get(rate_col) > 0]
-    size_vals = [r.get("building_sf") for r in rows
-                 if isinstance(r.get("building_sf"), (int, float)) and r.get("building_sf") > 0]
+    size_col = "building_sf" if tx == "sale" else "leased_sf"
+    size_vals = [r.get(size_col) for r in rows
+                 if isinstance(r.get(size_col), (int, float)) and r.get(size_col) > 0]
 
     def _stat(label: str, fn, vals, row_idx: int) -> None:
         summary.cell(row=row_idx, column=1, value=label).font = Font(bold=True)
@@ -613,8 +621,8 @@ def format_excel(
     _stat(f"Median {rate_col}", statistics.median, rate_vals, 3)
     _stat(f"Min {rate_col}", min, rate_vals, 4)
     _stat(f"Max {rate_col}", max, rate_vals, 5)
-    _stat("Avg building_sf", statistics.mean, size_vals, 6)
-    _stat("Median building_sf", statistics.median, size_vals, 7)
+    _stat(f"Avg {size_col}", statistics.mean, size_vals, 6)
+    _stat(f"Median {size_col}", statistics.median, size_vals, 7)
 
     # --- Sheet 3: Methodology ---
     meth = wb.create_sheet("Methodology")
@@ -696,7 +704,7 @@ def markdown_table(
         for i, r in enumerate(top_n, start=1):
             parts.append(
                 f"| {i} | {r.get('property_address','—')} | {r.get('property_city','—')} | "
-                f"{r.get('county','—')} | {_fmt_int(r.get('building_sf'))} | "
+                f"{r.get('county','—')} | {_fmt_int(r.get('leased_sf'))} | "
                 f"{_fmt_rate(r.get('base_rent'))} | {r.get('rent_type','—')} | "
                 f"{r.get('lease_term_months','—')} | {r.get('tenant_name','—')} | "
                 f"{r.get('lease_start_date','—')} | {(r.get('tenant_industry') or '')[:40]} |"

--- a/plugins/lee-internal-comps/skills/internal-and-external-comps/SKILL.md
+++ b/plugins/lee-internal-comps/skills/internal-and-external-comps/SKILL.md
@@ -102,10 +102,11 @@ external = load_sibling("external-comps")
 3. **One transaction type per request.** If the broker mixes sale and lease, ask them to split
    into two runs (same rule as the single-source skills).
 4. **Source tagging is non-negotiable.** Every row, in every output, shows its Source.
-5. **External lease "Leased SF" is blank by design.** The external platform's external lease data carries the
-   building size, not the true leased premises area, so for external lease rows the
-   "Leased SF" column renders **blank** — building size is never shown as Leased SF (gi-plugins#105).
-   Internal (Dealius) lease rows keep their real leased area (`space_sf`).
+5. **External lease "Leased SF" is the leased premises, never the building.** External lease
+   rows carry `leased_sf` (the space the tenant took; lee#469) and the "Leased SF" column shows
+   it. `building_sf` is the building footprint and is never shown as Leased SF (gi-plugins#105);
+   a row without `leased_sf` renders blank. Internal (Dealius) lease rows keep `space_sf`.
+   When the external pull takes a size range for a lease, send it as `min/max_leased_sf`.
 
 ## Output
 

--- a/plugins/lee-internal-comps/skills/internal-and-external-comps/helpers.py
+++ b/plugins/lee-internal-comps/skills/internal-and-external-comps/helpers.py
@@ -108,12 +108,13 @@ def to_core(row: dict, source: str, tx_type: str) -> dict:
         date = _first(row, "lease_execution", "lease_commencement")
         lease_type = row.get("lease_type")
     else:
-        # The external lease ingest carries building_sf (building size) but NO
-        # true leased-area field. We must NOT show building size as "Leased SF"
-        # (gi-plugins#105, Will Fogleman 2026-06-17) — render it BLANK rather than
-        # mislabel building size as the leased premises. Internal Dealius rows keep
-        # their real space_sf above.
-        leased = None
+        # leased_sf is the external platform's "Size Leased SF", promoted to a
+        # typed column and backfilled (lee#469, closes lee#180). building_sf is the
+        # building footprint and must NEVER stand in for the leased premises
+        # (gi-plugins#105, Will Fogleman 2026-06-17): a row without leased_sf
+        # renders BLANK rather than mislabel building size. 0 is an unknown-value
+        # placeholder, never a real size (gi-plugins#82), so it renders blank too.
+        leased = row.get("leased_sf") or None
         rent = row.get("base_rent")
         asking = None
         date = row.get("lease_start_date")
@@ -206,8 +207,9 @@ def _fmt(value) -> str:
 def unified_markdown_table(core_rows: list, validated: dict) -> str:
     """Combined chat table over the core columns, Source first.
 
-    External lease rows render a blank "Leased SF" (the external platform carries no true
-    leased area; gi-plugins#105), so there is no building-size-substitution footnote.
+    External lease rows show the leased premises (`leased_sf`, lee#469) or blank when
+    it is absent — never the building size (gi-plugins#105), so there is no
+    building-size-substitution footnote.
     """
     tx_type = validated.get("comp_type") or validated.get("transaction_type") or "sale"
     cols = _core_columns(tx_type)

--- a/plugins/lee-internal-comps/skills/internal-and-external-comps/test_helpers.py
+++ b/plugins/lee-internal-comps/skills/internal-and-external-comps/test_helpers.py
@@ -75,20 +75,32 @@ def test_to_core_internal_lease():
     assert core["effective_rate"] == 9.5 and core["space_sf"] == 12000
 
 
-def test_to_core_external_lease_leased_sf_is_blank():
-    # gi-plugins#105: The external platform carries no true leased area for leases, so "Leased SF"
-    # must render BLANK for external lease rows — never the building size.
+def test_to_core_external_lease_leased_sf_is_the_leased_premises():
+    # lee#469 (closes lee#180 / gi-plugins#105 interim): the external lease row now
+    # carries the promoted leased_sf; "Leased SF" shows it and never the building size.
     row = {"external_id": "e2", "property_address": "4 D St", "property_city": "Apex",
            "county": "Wake", "property_type": "Industrial", "building_sf": 40000,
-           "base_rent": 11.0, "lease_start_date": "2025-05-01", "rent_type": "Gross"}
+           "leased_sf": 3075, "base_rent": 11.0, "lease_start_date": "2025-05-01",
+           "rent_type": "Gross"}
     core = to_core(row, SOURCE_EXTERNAL, "lease")
-    assert core["Leased SF"] is None
-    assert core["Leased SF"] != 40000          # building size must not leak in
+    assert core["Leased SF"] == 3075
     assert core["Rent"] == 11.0
     assert core["Lease Type"] == "Gross"
     assert "_leased_sf_is_building_size" not in core
-    # space_sf stat key mirrors the (now-blank) leased value.
-    assert core["effective_rate"] == 11.0 and core["space_sf"] is None
+    assert core["effective_rate"] == 11.0 and core["space_sf"] == 3075
+
+
+def test_to_core_external_lease_without_leased_sf_stays_blank_never_building_sf():
+    # A row not yet backfilled (leased_sf NULL) renders blank, not the footprint.
+    row = {"external_id": "e3", "property_address": "5 E St", "property_city": "Apex",
+           "building_sf": 40000, "leased_sf": None, "base_rent": 11.0,
+           "lease_start_date": "2025-05-01"}
+    core = to_core(row, SOURCE_EXTERNAL, "lease")
+    assert core["Leased SF"] is None
+    assert core["space_sf"] is None
+    # 0 is a placeholder (gi-plugins#82), never shown as a size
+    zero = to_core({**row, "leased_sf": 0}, SOURCE_EXTERNAL, "lease")
+    assert zero["Leased SF"] is None and zero["space_sf"] is None
 
 
 def test_combine_keeps_both_rows_and_sorts_desc():

--- a/plugins/lee-internal-comps/skills/internal-and-external-comps/test_leased_sf_external.py
+++ b/plugins/lee-internal-comps/skills/internal-and-external-comps/test_leased_sf_external.py
@@ -1,20 +1,19 @@
 """
-External lease rows must NOT show building SF in the "Leased SF" column
-(gi-plugins#105).
+External lease rows show the leased PREMISES size in "Leased SF" (lee#469),
+and never the building SF (gi-plugins#105).
 
 Broker request (Will Fogleman, Lee, 2026-06-17 'Initial Feedback' email):
 "For external lease records, 'Leased SF' appears to be pulling the total
 building square footage instead of the actual leased area. Please ensure this
 field reflects the leased premises and not the building size."
 
-Root cause: The external platform's external lease ingest carries `building_sf` but NO true
-leased-area field (confirmed against external-comps DISPLAY_COLUMNS_LEASE and the
-lee external-comps-db schema). The unified skill previously mapped `building_sf`
-into the Leased SF slot under a W1 footnote. Since the data genuinely lacks leased
-area, the correct broker-honest behavior is to render Leased SF BLANK for external
-lease rows (internal rows, which carry a real space_sf, are unchanged).
+History: the external lease ingest carried only `building_sf` in the typed
+schema, so gi-plugins#105 blanked the column rather than show the footprint.
+lee#469 promoted the raw "Size Leased SF" to `comps_external.leased_sf`
+(backfilled), so the column now shows the real leased area. A row without
+`leased_sf` (not yet backfilled) still renders blank, never the building size.
 
-Card: davidmshaner-gi/gi-plugins#105.
+Cards: davidmshaner-gi/gi-plugins#105 (interim), lee-and-associates#469 (fix).
 """
 
 import os
@@ -33,9 +32,11 @@ from helpers import (  # noqa: E402
 EXT_LEASE = {
     "external_property_id": "C-1", "property_address": "3 Pine St",
     "property_city": "Durham", "county": "Durham", "property_type": "Industrial",
-    "building_sf": 60000, "base_rent": 10.0, "rent_type": "NNN",
+    "building_sf": 60000, "leased_sf": 8400, "base_rent": 10.0, "rent_type": "NNN",
     "lease_start_date": "2026-01-01",
 }
+
+EXT_LEASE_NO_LEASED = {**EXT_LEASE, "leased_sf": None}
 
 INT_LEASE = {
     "comps_id": "i1", "street_address": "1 A St", "city": "Garner", "county": "Wake",
@@ -45,12 +46,17 @@ INT_LEASE = {
 }
 
 
-def test_external_lease_leased_sf_is_blank_not_building_sf():
+def test_external_lease_leased_sf_is_the_leased_premises():
     core = to_core(EXT_LEASE, SOURCE_EXTERNAL, "lease")
+    assert core["Leased SF"] == 8400
+    assert core["Leased SF"] != EXT_LEASE["building_sf"]
+
+
+def test_external_lease_without_leased_sf_is_blank_not_building_sf():
+    core = to_core(EXT_LEASE_NO_LEASED, SOURCE_EXTERNAL, "lease")
     assert core["Leased SF"] in (None, ""), (
         f"external lease Leased SF must be blank, got {core['Leased SF']!r}"
     )
-    # Specifically, it must NOT be the building size.
     assert core["Leased SF"] != EXT_LEASE["building_sf"]
 
 
@@ -67,15 +73,16 @@ def test_internal_lease_leased_sf_unchanged():
     assert core["Leased SF"] == 12500
 
 
-def test_unified_lease_table_blanks_external_leased_sf():
+def test_unified_lease_table_shows_external_leased_sf_never_building_sf():
     rows = combine(
         [to_core(INT_LEASE, SOURCE_INTERNAL, "lease")],
         [to_core(EXT_LEASE, SOURCE_EXTERNAL, "lease")],
         "lease",
     )
     md = unified_markdown_table(rows, {"comp_type": "lease"})
-    # The external row's Leased SF cell is empty; the building size never appears
-    # as a Leased SF value.
+    # The external row's Leased SF is the leased area; the building size never
+    # appears as a Leased SF value.
+    assert "8400" in md
     assert "60000" not in md, "building SF leaked into the unified lease table"
     # The W1 'building size, not leased area' footnote should be gone.
     assert "building size, not leased area" not in md

--- a/plugins/lee-internal-comps/tests/test_external_lease_leased_sf.py
+++ b/plugins/lee-internal-comps/tests/test_external_lease_leased_sf.py
@@ -1,0 +1,96 @@
+"""
+External lease comps size on the leased PREMISES, not the building (lee#469).
+
+Christian Sommer (Lee, 2026-08-21) asked for Apex lease comps 2,000–20,000 SF and
+got zero rows: the skill sent the broker's size range as `min/max_building_sf`,
+which the Worker applied to `building_sf` — the building footprint, NULL on most
+external lease rows. The Worker now exposes `leased_sf` (the promoted "Size
+Leased SF") and `min/max_leased_sf` on `search_external_lease_comps`; these tests
+pin that the skill drives the new params for leases (and still building_sf for
+sales) and that every lease size surface — Excel column, Summary stats, chat
+table, ranking — reads `leased_sf`.
+
+Card: davidmshaner-gi/lee-and-associates#469 (sibling of Worker 0.43.0).
+"""
+
+import os
+import tempfile
+
+from openpyxl import load_workbook
+
+from conftest import load_skill_helpers
+
+helpers = load_skill_helpers("external-comps")
+
+LEASE_REQ = {
+    "asset_type": "flex", "transaction_type": "lease",
+    "geography": {"cities": ["Apex"]},
+    "size_range": {"min_sf": 2000, "max_sf": 20000},
+    "date_window": {"months": 36},
+}
+SALE_REQ = {**LEASE_REQ, "transaction_type": "sale", "asset_type": "industrial"}
+
+LEASE_ROW = {
+    "external_id": "x1", "property_address": "2019 Production Dr", "property_city": "Apex",
+    "county": "Wake", "submarket": "Apex/Holly Springs", "property_type": "Flex",
+    "building_sf": None, "leased_sf": 3075, "lease_start_date": "2024-08-01",
+    "lease_term_months": 60, "base_rent": 14.5, "rent_type": "NNN", "tenant_name": "Acme",
+}
+LEASE_ROW_2 = {**LEASE_ROW, "external_id": "x2", "property_address": "1460 Chapel Ridge Rd",
+               "building_sf": 47874, "leased_sf": 3240, "base_rent": 15.0}
+
+
+def test_lease_size_range_maps_to_leased_sf_params():
+    v = helpers.validate_request(LEASE_REQ)["validated"]
+    out = helpers.build_mcp_params(v)
+    assert out["tool_name"] == "search_external_lease_comps"
+    p = out["params_list"][0]
+    assert p["min_leased_sf"] == 2000 and p["max_leased_sf"] == 20000
+    assert "min_building_sf" not in p and "max_building_sf" not in p
+
+
+def test_sale_size_range_still_maps_to_building_sf_params():
+    v = helpers.validate_request(SALE_REQ)["validated"]
+    p = helpers.build_mcp_params(v)["params_list"][0]
+    assert p["min_building_sf"] == 2000 and p["max_building_sf"] == 20000
+    assert "min_leased_sf" not in p
+
+
+def test_lease_display_columns_carry_leased_sf_before_building_sf():
+    cols = helpers.DISPLAY_COLUMNS_LEASE
+    assert "leased_sf" in cols
+    assert cols.index("leased_sf") < cols.index("building_sf")
+
+
+def test_lease_ranking_size_proximity_uses_leased_sf():
+    v = helpers.validate_request({**LEASE_REQ, "size_range": {"min_sf": 3200, "max_sf": 3300}})["validated"]
+    # x2 (3,240) sits nearer the 3,250 midpoint than x1 (3,075); same date, so size decides.
+    # A building_sf of 47,874 on x2 must not push it away.
+    top, _, _, _ = helpers.rank_comps([LEASE_ROW, LEASE_ROW_2], v)
+    assert top[0]["external_id"] == "x2"
+
+
+def test_lease_markdown_sf_column_is_leased_sf():
+    v = helpers.validate_request(LEASE_REQ)["validated"]
+    top, uc, sub, undisc = helpers.rank_comps([LEASE_ROW_2], v)
+    md = helpers.markdown_table(top, uc, sub, undisc, v)
+    assert "3,240" in md
+    assert "47,874" not in md
+
+
+def test_lease_excel_summary_stats_use_leased_sf():
+    v = helpers.validate_request(LEASE_REQ)["validated"]
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as d:
+        os.chdir(d)  # format_excel writes c.xlsx into the CWD (safe_xlsx_name)
+        try:
+            out = helpers.format_excel([LEASE_ROW, LEASE_ROW_2], v, "out.xlsx", [], [], [])
+            wb = load_workbook(out)
+        finally:
+            os.chdir(cwd)
+        summary = wb["Summary"]
+        labels = {summary.cell(row=r, column=1).value: summary.cell(row=r, column=2).value
+                  for r in range(1, 12)}
+        assert labels.get("Avg leased_sf") == (3075 + 3240) / 2
+        assert labels.get("Median leased_sf") == (3075 + 3240) / 2
+        assert "Avg building_sf" not in labels


### PR DESCRIPTION
## What changed
A lease size range now goes to the Worker as the space leased (`min/max_leased_sf`), and external lease rows show their real "Leased SF" instead of a blank, so size-filtered external lease pulls return comps again.

Refs davidmshaner-gi/lee-and-associates#469 (sibling of Worker 0.43.0; merge AFTER that PR is merged + migrated + deployed, since the new params only exist on 0.43.0 — older Workers would reject `min_leased_sf`).

- `external-comps`: `size_range` → `min/max_leased_sf` for leases (sales still `building_sf`); `leased_sf` in lease Excel columns, ranking, Summary stats, chat table; SKILL.md param table + empty-result note name the lease filter.
- `internal-and-external-comps`: retires the #105 blank; "Leased SF" = `leased_sf` for external lease rows, blank when absent or 0, never `building_sf`.
- 1.33.0 → 1.34.0, CHANGELOG.

## Checklist
- [x] Linked to issue (`Refs`, broker-facing → QA)
- [x] Version bumped (both manifests)
- [x] `CHANGELOG.md` updated
- [x] skill-contract-check passed (pre-commit)
- [x] pytest 59 + 18 + 2 passed; independent diff review run, Important findings fixed
- [ ] Worktree cleanup after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9JcJ1At3m4nt5Ng5s5zTr
