### PR TITLE
add-comps: dry-run duplicate check before every write + import undo (1.36.0; lee#74)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lee-internal-comps",
       "source": "./plugins/lee-internal-comps",
       "description": "Lee & Associates broker toolkit. Comps (Lee internal and external, lease and sale) as Excel + Lee-branded PDF; demographic and business-key-facts reports; owner, parcel, and mailing-list lookups; traffic counts, labor shed, drive times (reach maps + drive times to named destinations), site infrastructure, development pipeline, and tenants in the market; comp maps and area-amenities map kits; a guided flyer brief; and Lee branding for anything you build. Ask in plain English or use /comps, /internal-comps, /demographic-summary, /owner-lookup and the rest.",
-      "version": "1.35.0"
+      "version": "1.36.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Brokers pick up releases by syncing the marketplace in Cowork (auto-sync toggle 
 via `/plugin update`. `marketplace.json` and `plugins/lee-internal-comps/.claude-plugin/plugin.json`
 carry the same version as of 1.4.0.
 
+## [1.36.0] - 2026-08-24
+
+### Added
+- **add-comps: duplicate check before every write + import undo (lee#74; Worker 0.47.0).**
+  The skill now calls `lee_comps_add_write` with `dry_run: true` first, shows the broker
+  any rows that look like comps already in the contributed book (same address, deal
+  size, and rent/tenant or price/buyer), and only writes after they decide. Remaining
+  likely duplicates are flagged, never dropped. A mistaken import is reversible with
+  `lee_comps_delete_import` by its `import_id`.
+
 ## [1.35.0] - 2026-08-24
 
 ### Added

--- a/plugins/lee-internal-comps/.claude-plugin/plugin.json
+++ b/plugins/lee-internal-comps/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lee-internal-comps",
   "description": "Lee & Associates broker toolkit. Comps (Lee internal and external, lease and sale) as Excel + Lee-branded PDF; demographic and business-key-facts reports; owner, parcel, and mailing-list lookups; traffic counts, labor shed, drive times (reach maps + drive times to named destinations), site infrastructure, development pipeline, and tenants in the market; comp maps and area-amenities map kits; a guided flyer brief; and Lee branding for anything you build. Ask in plain English or use /comps, /internal-comps, /demographic-summary, /owner-lookup and the rest.",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "author": {
     "name": "Grounded Intelligence"
   },

--- a/plugins/lee-internal-comps/skills/add-comps/SKILL.md
+++ b/plugins/lee-internal-comps/skills/add-comps/SKILL.md
@@ -11,7 +11,8 @@ brokerage shop has pasted several comp tables — into clean, canonical
 comps database via the `lee_comps_add_write` MCP tool.
 
 The helpers are deterministic and run in the Cowork sandbox. The model
-orchestrates and performs the MCP write; the sandbox has no MCP access.
+orthestrates and performs the dry run and the MCP write (see "Write flow"
+below); the sandbox has no MCP access.
 
 ## When to use
 
@@ -66,21 +67,29 @@ database. Typical shapes:
    dict the `lee_comps_add_write` MCP tool expects (`added_by`,
    `import_method`, `raw_blob`, `parser_version` from the `PARSER_VERSION`
    constant, `rows`, plus optional `client_id` / `source_label` /
-   `raw_blob_ref` / `notes`). The model performs the actual MCP write.
+   `raw_blob_ref` / `notes`). The model performs the dry run and the actual MCP
+   write (see "Write flow").
 
 ## Write flow (the model's job — do this every time)
 
 1. **Dry run first.** Call `lee_comps_add_write` with the assembled payload **plus
    `dry_run: true`**. It returns, per row, `new` or `likely_duplicate` with the
    matching `added_comp_id` / `import_id` / `original_source` from the contributed
-   book. Nothing is written.
+   book. Nothing is written. (This is the server-side duplicate check against the
+   book, separate from the local `dry_run_summary` helper, which only reports
+   missing fields.) The response must echo `dry_run: true` and `import_id: null`;
+   if it instead returns a numeric `import_id`, the server wrote — tell the broker
+   immediately and offer the undo in step 4.
 2. **Show the broker the likely duplicates** (address, tenant or buyer, size, rent or
    price, and which earlier import they match). Ask whether to drop them from this
    import, keep them, or stop. Rows the broker drops: remove them from `rows` before
-   the real write. Never silently drop or merge on the broker's behalf.
+   the real write. Never silently drop or merge on the broker's behalf. If every row
+   matches the same earlier `import_id`, this set is already loaded — say so and
+   stop; do not write. If the broker drops every row, there is nothing to write — stop.
 3. **Write.** Call `lee_comps_add_write` again WITHOUT `dry_run`. Any remaining likely
    duplicates are inserted but flagged (`flagged=1`, `flag_reason` names the match) and
-   echoed back as `likely_duplicates` — tell the broker the count and the `import_id`.
+   echoed back as `likely_duplicates` — tell the broker `added`, the likely-duplicate
+   count, and the `import_id`.
 4. **Undo.** If the broker says the import was a mistake, call
    `lee_comps_delete_import` with that `import_id` (confirm first — it deletes every
    comp that import wrote and the import record, and cannot be undone). The same file

--- a/plugins/lee-internal-comps/skills/add-comps/SKILL.md
+++ b/plugins/lee-internal-comps/skills/add-comps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-comps
-description: Normalize a contributed comp set a Lee broker pastes, forwards, or uploads (a forwarded email with several brokerage comp tables, an xlsx/csv export, a pasted tab/pipe table, or a screenshot) into canonical AddCompRow records ready for ingestion via the lee_comps_add_write MCP tool. parse_email extracts the comp tables from a forwarded email body, attaches the contributing source (JLL, Foundry, etc.) to each row, and skips signature / confidentiality decoy tables. parse_spreadsheet reads an xlsx or csv, picks the comp-shaped sheet(s) and skips prose/view tabs, and raises AmbiguousSheetError when more than one comp sheet is present so the operator can choose. parse_text parses a pasted tab- or pipe-delimited table. parse_image and llm_fallback extract rows via an injected model-vision callable (the skill's own Claude runtime) for screenshots or blobs the deterministic parsers can't handle. detect_transaction_type decides lease vs. sale from the column headers. apply_alias_map folds contributor headers into the canonical keys, coerces numerics (strips $ , %), preserves the verbatim Transaction Type as txn_subtype, and keeps any unmapped columns in raw_fields_json. validate_row flags (never drops) rows missing the minimum keys. dry_run_summary reports total + per-source counts + flagged rows for operator review, and build_write_payload assembles the exact AddCompsPayload (with parser_version) for the lee_comps_add_write MCP tool — the MCP write itself is the model's job.
+description: Normalize a contributed comp set a Lee broker pastes, forwards, or uploads (a forwarded email with several brokerage comp tables, an xlsx/csv export, a pasted tab/pipe table, or a screenshot) into canonical AddCompRow records ready for ingestion via the lee_comps_add_write MCP tool. parse_email extracts the comp tables from a forwarded email body, attaches the contributing source (JLL, Foundry, etc.) to each row, and skips signature / confidentiality decoy tables. parse_spreadsheet reads an xlsx or csv, picks the comp-shaped sheet(s) and skips prose/view tabs, and raises AmbiguousSheetError when more than one comp sheet is present so the operator can choose. parse_text parses a pasted tab- or pipe-delimited table. parse_image and llm_fallback extract rows via an injected model-vision callable (the skill's own Claude runtime) for screenshots or blobs the deterministic parsers can't handle. detect_transaction_type decides lease vs. sale from the column headers. apply_alias_map folds contributor headers into the canonical keys, coerces numerics (strips $ , %), preserves the verbatim Transaction Type as txn_subtype, and keeps any unmapped columns in raw_fields_json. validate_row flags (never drops) rows missing the minimum keys. dry_run_summary reports total + per-source counts + flagged rows for operator review, and build_write_payload assembles the exact AddCompsPayload (with parser_version) for the lee_comps_add_write MCP tool. The model then calls lee_comps_add_write with dry_run=true first, shows the broker any likely duplicates already in the contributed book, and only then writes; a bad import is reversible with lee_comps_delete_import by its import_id.
 ---
 
 # Add Comps (Lee & Associates)
@@ -68,6 +68,24 @@ database. Typical shapes:
    constant, `rows`, plus optional `client_id` / `source_label` /
    `raw_blob_ref` / `notes`). The model performs the actual MCP write.
 
+## Write flow (the model's job — do this every time)
+
+1. **Dry run first.** Call `lee_comps_add_write` with the assembled payload **plus
+   `dry_run: true`**. It returns, per row, `new` or `likely_duplicate` with the
+   matching `added_comp_id` / `import_id` / `original_source` from the contributed
+   book. Nothing is written.
+2. **Show the broker the likely duplicates** (address, tenant or buyer, size, rent or
+   price, and which earlier import they match). Ask whether to drop them from this
+   import, keep them, or stop. Rows the broker drops: remove them from `rows` before
+   the real write. Never silently drop or merge on the broker's behalf.
+3. **Write.** Call `lee_comps_add_write` again WITHOUT `dry_run`. Any remaining likely
+   duplicates are inserted but flagged (`flagged=1`, `flag_reason` names the match) and
+   echoed back as `likely_duplicates` — tell the broker the count and the `import_id`.
+4. **Undo.** If the broker says the import was a mistake, call
+   `lee_comps_delete_import` with that `import_id` (confirm first — it deletes every
+   comp that import wrote and the import record, and cannot be undone). The same file
+   can then be re-imported after corrections.
+
 ## Importing the helpers (read before writing a script)
 
 `helpers.py` lives in THIS skill's own directory, which is **not** on the Cowork
@@ -96,9 +114,9 @@ The output keys match the `lee_comps_add_write` MCP tool's `AddCompRow` exactly
 
 ## Out of scope
 
-- The MCP write itself (`lee_comps_add_write`) — the model performs it after the
-  broker reviews the normalized rows (`build_write_payload` assembles the
-  payload; the model calls the tool).
+- The helpers never call MCP — the sandbox has no MCP access. The model performs
+  the dry run, the write, and any undo per "Write flow" above (`build_write_payload`
+  assembles the payload; the model calls the tools).
 
 ## Tests
 


### PR DESCRIPTION
## What changed
`/add-comps` now runs a duplicate check against the internal book before every write and shows the broker what it found; a mistaken import can be undone.

Refs davidmshaner-gi/lee-and-associates#74. Sibling of the Worker PR (0.47.0) -- G11 sub-case (d): the Worker's new `dry_run` param and `lee_comps_delete_import` tool are inert until this SKILL.md drives them.

- `skills/add-comps/SKILL.md`: frontmatter description names the dry-run-first flow and the undo; new "Write flow" section (dry run -> show duplicates -> broker decides -> write -> undo); "Out of scope" reworded.
- 1.34.0 -> 1.35.0 (marketplace.json + plugin.json), CHANGELOG.
- `skill-contract-check.sh` PASS; connector-auth block untouched (guidance check PASS); source-neutrality clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZrFNQGLAGYdQ1W85EFbG7