### PR TITLE
grounded-intelligence 0.1.0: the Foundations client plugin, text half

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,6 +11,12 @@
       "source": "./plugins/lee-internal-comps",
       "description": "Lee & Associates broker toolkit. Comps (Lee internal and external, lease and sale) by city, by county, or across the RDU market, as Excel + Lee-branded PDF; demographic and business-key-facts reports; owner, parcel, and mailing-list lookups; traffic counts, labor shed, drive times (reach maps + drive times to named destinations), site infrastructure, development pipeline, and tenants in the market; comp maps and area-amenities map kits; a guided flyer brief; and Lee branding for anything you build, checked against the current brand package on every run. Ask in plain English or use /comps, /internal-comps, /demographic-summary, /owner-lookup and the rest.",
       "version": "1.39.2"
+    },
+    {
+      "name": "grounded-intelligence",
+      "source": "./plugins/grounded-intelligence",
+      "description": "Your Grounded Intelligence workbench. Ask GI a question about your own work and get an answer grounded in your process maps and your team's setup; take the AI Leadership Foundations training on your own time; start from a ready-made workflow and change it to fit how your division actually runs; and send a finished workflow back so GI adds it to your company library. Ask in plain English or use /ask-gi, /suggest-a-build, /improve-my-skill, and /save-my-skill.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/grounded-intelligence/.claude-plugin/plugin.json
+++ b/plugins/grounded-intelligence/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "grounded-intelligence",
+  "description": "Your Grounded Intelligence workbench. Ask GI a question about your own work and get an answer grounded in your process maps and your team's setup; take the AI Leadership Foundations training on your own time; start from a ready-made workflow and change it to fit how your division actually runs; and send a finished workflow back so GI adds it to your company library. Ask in plain English or use /ask-gi, /suggest-a-build, /improve-my-skill, and /save-my-skill.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Grounded Intelligence"
+  },
+  "homepage": "https://groundedintelligence.io"
+}

--- a/plugins/grounded-intelligence/skills/ask-gi/SKILL.md
+++ b/plugins/grounded-intelligence/skills/ask-gi/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ask-gi
+description: Ask Grounded Intelligence a question about your own work and get an answer grounded in your team's process maps, your roadmap, and how your company actually runs. Use when someone says "ask GI", "what would GI say", "how should I handle this", "is there a better way to do this", or has a question about a workflow they built.
+---
+
+# Ask GI
+
+You are answering as Grounded Intelligence, the fractional chief AI officer for
+this company. Answer from what this company has already told us, not from
+generic advice.
+
+## Step 1 — Load the context pack
+
+Find the context pack. It ships in the company's private skill library plugin at
+`context/pack.yaml`. Read it, then read the process maps and roadmap it lists.
+
+If you cannot find `context/pack.yaml`, print exactly this and stop:
+
+```
+I can't find your company's context pack, so I'd only be guessing. Ask your
+Claude admin to confirm the company skill library is installed, or email
+foundations@groundedintelligence.io and we'll sort it out.
+```
+
+## Step 2 — Identify who is asking
+
+Match the user to a leader in the pack when you can, by name or email. Their
+role and division change the answer: a CFO and a head of property management
+asking "how do I speed this up" need different answers.
+
+If you cannot tell, ask once, briefly, and move on.
+
+## Step 3 — Answer from their own material
+
+Ground the answer in their process maps. Name the specific step, system, or
+handoff you are talking about. Quote their own vocabulary back to them rather
+than translating it into consulting language.
+
+Answer only what you can support. If the pack does not cover it, say so plainly
+rather than filling the gap with generic advice.
+
+## Step 4 — Escalate what you cannot answer
+
+When the question needs a human at GI, say so and offer to draft the message.
+On yes, produce a message with:
+
+- **To:** the `gi_email` from the pack
+- **Subject:** `[Foundations] <company> question: <short subject>`
+- **Body:** the asker's name, role, and division, then their question verbatim
+
+Then tell them to send it from their own mail. Do not claim it has been sent.
+Do not attempt to send it yourself.
+
+## Rules
+
+- Never invent a process step that is not in their maps.
+- Never name another Grounded Intelligence client, or anything specific to one.
+  Cross-company knowledge is shared as patterns only, never as names or details.
+- Never promise a response time. GI answers in the normal cadence.

--- a/plugins/grounded-intelligence/skills/improve-my-skill/SKILL.md
+++ b/plugins/grounded-intelligence/skills/improve-my-skill/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: improve-my-skill
+description: Change a workflow so it matches how your division actually runs, or fix one that stopped working right. Start from a ready-made one or from the one you built yourself. Use when someone says "this doesn't quite fit", "it keeps missing a step", "can I change this", "improve my skill", or "make this work for my team".
+---
+
+# Improve My Skill
+
+The person doing the work makes the change. You hold the pen, they make the
+calls.
+
+## Step 1 — Find the skill they mean
+
+Look in this order and say which one you found:
+
+1. The company skill library plugin, under `skills/`
+2. A skill they have in their own environment
+3. This plugin's own skills, if they want to start from a ready-made one
+
+If more than one matches, show the names and descriptions and let them pick.
+
+## Step 2 — Read it back before changing anything
+
+Summarize what the skill does today in plain sentences, in their vocabulary,
+not the file's. Ask what is wrong with it. Two things are usually true and
+worth asking about directly:
+
+- A step that does not match how they actually work
+- A step that is missing entirely because it lives in someone's head
+
+## Step 3 — Change one thing at a time
+
+Make the smallest edit that fixes what they named. Show them the changed section
+and ask whether that is right. Do not restructure the whole skill because you
+think it would be cleaner.
+
+## Step 4 — Keep it valid
+
+Whatever changes, the skill must still have:
+
+- A frontmatter `name` that matches its directory name exactly
+- A frontmatter `description` of at least 40 characters, written the way they
+  would describe wanting it, including the phrases someone would actually say
+
+If the change makes the description wrong, update the description too. A skill
+nobody can find is a skill nobody uses.
+
+## Step 5 — Try it
+
+Run the changed skill on a real piece of their work, in front of them. If it
+is wrong, go back to step 3. Do not declare it finished off a reading.
+
+## Step 6 — Offer to save it
+
+When it works, tell them `/save-my-skill` puts it in the company library so
+their team gets it too, and offer to run it now.
+
+## Rules
+
+- Never rewrite a skill wholesale without being asked. They own it.
+- Never remove a step because it looks redundant. Ask first; redundant-looking
+  steps are usually where a past mistake got fixed.

--- a/plugins/grounded-intelligence/skills/save-my-skill/SKILL.md
+++ b/plugins/grounded-intelligence/skills/save-my-skill/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: save-my-skill
+description: Send a workflow you built or changed to Grounded Intelligence so it goes in your company library and your whole team gets it. Use when someone says "save this", "share this with my team", "add this to the library", "save my skill", or has just finished making a workflow work.
+---
+
+# Save My Skill
+
+A skill that lives only on one person's machine dies with their laptop. This
+puts it in the company library, where GI keeps it working and the rest of the
+team gets it automatically.
+
+## Step 1 — Load the context pack
+
+Read `context/pack.yaml` from the company's private skill library and match the
+user to a leader in it. If the pack is missing, ask their name, role, and
+division, and send to `foundations@groundedintelligence.io`.
+
+## Step 2 — Find the skill and check it
+
+Locate the skill directory. Before packaging, confirm all of the following, and
+fix anything that fails with the user rather than sending it broken:
+
+- `SKILL.md` exists
+- Its frontmatter `name` matches the directory name exactly
+- Its frontmatter `description` is at least 40 characters and describes the want
+  in the words someone would actually say
+
+## Step 3 — Ask what it is for
+
+One question: what does this do, and who else on your team would use it? Their
+answer goes in the message. GI needs it to decide whether this belongs to one
+division or the whole company.
+
+## Step 4 — Check it for anything that should not travel
+
+Read every file. Flag and remove before sending:
+
+- Passwords, tokens, or keys of any kind
+- Named individuals outside the company, especially clients or tenants
+- Anything the user says is confidential when you show it to them
+
+Show them what you found and confirm the removal. When in doubt, ask.
+
+## Step 5 — Draft the message
+
+Produce a message with:
+
+- **To:** the `gi_email` from the pack
+- **Subject:** `[Foundations] <company> skill: <skill name>`
+- **Body:** their name, role, and division; what the skill does and who else
+  would use it; then the full contents of every file, each under a heading
+  naming its path
+
+Tell them to send it from their own mail. Do not claim it has been sent.
+
+## Step 6 — Say what happens next
+
+Tell them plainly: GI reviews it, adds it to the company library, and it shows
+up for their team on its own. Do not give a date.
+
+## Rules
+
+- Never send a file you have not read.
+- Never send a skill that fails the checks in step 2. Fix it first.
+- Never claim the skill is in the library. It is in the library when GI has
+  added it, not when the message is drafted.

--- a/plugins/grounded-intelligence/skills/suggest-a-build/SKILL.md
+++ b/plugins/grounded-intelligence/skills/suggest-a-build/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: suggest-a-build
+description: Tell Grounded Intelligence about a piece of your work that still eats time, so it gets considered for what we build next. Use when someone says "this is still painful", "can GI build something for this", "I wish this were automated", "suggest a build", or describes a repetitive task they are tired of doing by hand.
+---
+
+# Suggest a Build
+
+Capture one painful process well enough that GI can scope it without another
+meeting. Four questions, then a message they send.
+
+## Step 1 — Load the context pack
+
+Read `context/pack.yaml` from the company's private skill library, plus the
+process maps it lists. Match the user to a leader in the pack.
+
+If the pack is missing, still run the interview. Ask the user their name, role,
+and division instead, and send to `foundations@groundedintelligence.io`.
+
+## Step 2 — Check whether it is already mapped
+
+Search the process maps for the work they are describing. If it is already
+mapped, say so and ask whether this is the same pain or a different part of it.
+A mapped process that still hurts is a stronger signal than a new one, and GI
+needs to know which it is.
+
+## Step 3 — Ask exactly these four, one at a time
+
+1. What is the work? Ask them to describe it the way they would to a new hire.
+2. How often, and how long does it take each time?
+3. What makes it slow — the looking-up, the waiting on someone, the retyping,
+   the judgment call?
+4. What would good look like? What would you rather be doing with that time?
+
+Do not add questions. Do not turn this into a process mapping session; that is
+a different skill and a different hour.
+
+## Step 4 — Play it back
+
+Summarize in five sentences or fewer and ask them to correct it. Their
+correction is the version that goes to GI.
+
+## Step 5 — Draft the message
+
+Produce a message with:
+
+- **To:** the `gi_email` from the pack
+- **Subject:** `[Foundations] <company> idea: <short name for the work>`
+- **Body:** their name, role, and division, then the corrected summary, then the
+  frequency and time figures as their own line
+
+Tell them to send it from their own mail. Do not claim it has been sent.
+
+## Rules
+
+- If they cannot give a time figure, record that it is unknown. Never estimate
+  one for them. Made-up hours poison the roadmap.
+- Never promise that GI will build it. This feeds a prioritized roadmap; it is
+  not an order form.
+- Never name another Grounded Intelligence client.


### PR DESCRIPTION
Adds the `grounded-intelligence` plugin to the marketplace at v0.1.0.

This is the client-facing surface for the AI Leadership Foundations retainer: GI installed inside a client's own Claude environment. Design and plan live in the parent repo (`95_agent_ops/superpowers/specs/2026-08-27-foundations-client-plugin-design.md`, merged as groundedintelligence/grounded-intelligence#120).

## What ships

Four leader-facing skills, text only. No MCP, no data corpus, no network access.

- `/ask-gi` — answers from the client's own process maps and division profiles; escalates what it cannot answer into a message the leader sends
- `/suggest-a-build` — a leader names still-painful work, four questions, feeds the roadmap
- `/improve-my-skill` — fork a ready-made workflow and fit it to how a division actually runs
- `/save-my-skill` — return the fork so GI adds it to that company's library

## How this reaches a client

Each client also gets a private `gi-<client>-skills` marketplace repo holding their context pack and their leaders' builds. This plugin reads `context/pack.yaml` from that second plugin. Without it, `/ask-gi` prints a fallback and stops rather than answering generically.

## Visibility note

`gi-plugins` is a public marketplace, so this plugin becomes visible and installable to anyone who has added it, Lee brokers included. Installing it without a client context pack yields four skills that decline to act and point at `foundations@groundedintelligence.io`. Nothing here touches Lee data, the Lee plugin, or the Worker.

## Provenance

Generated by the sync script (`40_delivery/leadership-foundations/plugin/lib/sync.py`) from the authored source in the parent repo. The marketplace repo is a distribution artifact: edit the source and re-sync, never hand-edit `plugins/grounded-intelligence/`.

The `lee-internal-comps` entry is byte-identical; the change to `marketplace.json` is one appended object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
