### PR TITLE
lee-internal-comps 1.41.0: comps skills teach the property_type family vocabulary and offer miss.next[0] first (sibling of lee-raleigh-mcp 0.59.0, lee#532)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lee-internal-comps",
       "source": "./plugins/lee-internal-comps",
       "description": "Lee & Associates broker toolkit. Comps (Lee internal and external, lease and sale) by city, by county, or across the RDU market, as Excel + Lee-branded PDF; demographic and business-key-facts reports; owner, parcel, and mailing-list lookups; traffic counts, labor shed, drive times (reach maps + drive times to named destinations), site infrastructure, development pipeline, and tenants in the market; comp maps and area-amenities map kits; a guided flyer brief; and Lee branding for anything you build, checked against the current brand package on every run. Ask in plain English or use /comps, /internal-comps, /demographic-summary, /owner-lookup and the rest.",
-      "version": "1.40.0"
+      "version": "1.41.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Brokers pick up releases by syncing the marketplace in Cowork (auto-sync toggle 
 via `/plugin update`. `marketplace.json` and `plugins/lee-internal-comps/.claude-plugin/plugin.json`
 carry the same version as of 1.4.0.
 
+## [1.41.0] - 2026-09-03
+
+### Changed
+- **Comps skills teach the family vocabulary and the server-side relaxation ladder (lee#532,
+  Worker 0.59.0):** `external-comps`, `internal-and-external-comps` and `lee-flyer-brief` pass
+  the broker's family word for `property_type` (`retail` = the whole retail book incl. the
+  parenthesized shopping-center subtypes; `industrial` reaches flex/warehouse; `medical` is its
+  own family) and never probe per-subtype; on an empty result they offer `miss.next[0]` (the
+  first relaxed ask the Worker already found rows for, its rows in `miss.nearest[]`) before the
+  `empty_result` wording. `internal-comps` notes the typed tools now apply its taxonomy table
+  server-side. `pull_unified_comps` pages (`limit`/`offset`/`total`) and dated lease pulls filter
+  on `lease_date`. Merge after lee-raleigh-mcp 0.59.0 is live; refresh the connector tools list.
+
 ## [1.40.0] - 2026-09-02
 
 ### Added

--- a/plugins/lee-internal-comps/.claude-plugin/plugin.json
+++ b/plugins/lee-internal-comps/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lee-internal-comps",
   "description": "Lee & Associates broker toolkit. Comps (Lee internal and external, lease and sale) by city, by county, or across the RDU market, as Excel + Lee-branded PDF; demographic and business-key-facts reports; owner, parcel, and mailing-list lookups; traffic counts, labor shed, drive times (reach maps + drive times to named destinations), site infrastructure, development pipeline, and tenants in the market; comp maps and area-amenities map kits; a guided flyer brief; and Lee branding for anything you build, checked against the current brand package on every run. Ask in plain English or use /comps, /internal-comps, /demographic-summary, /owner-lookup and the rest.",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "author": {
     "name": "Grounded Intelligence"
   },

--- a/plugins/lee-internal-comps/skills/external-comps/SKILL.md
+++ b/plugins/lee-internal-comps/skills/external-comps/SKILL.md
@@ -44,7 +44,8 @@ The skill orchestrates pre-baked helpers in `helpers.py`. **Do not regenerate Ex
 
 5. Call `build_mcp_params(validated)` → `{"tool_name", "params_list", "post_filter_counties"}`. `tool_name` is `"search_external_sale_comps"` or `"search_external_lease_comps"` depending on `transaction_type`. `params_list` holds one params dict per MCP call: one per county for a `counties` ask **and for `named_market: "RDU MSA"` (its 7 counties)**, one per city for `cities`. **Helpers do NOT call MCP.** The model invokes the MCP tool directly, once per entry, and unions the rows with `merge_rows(*pages)`.
 6. Invoke the MCP tool with each params dict — issue the per-county / per-city calls **in parallel in one turn** (an RDU ask is seven calls; sequential turns blow the interactive budget). The response shape is `{"rows": [...], "freshness": "..."}` (a JSON-stringified text block from the MCP server — parse it). Each row contains all typed external columns plus `external_id` (as of Worker 0.53.1, search rows do NOT carry `raw_fields_json` — the ~2.3KB/row blob made large results unreadable in the client; use `get_external_comp_detail` for a row's full record). **If `freshness` is present, emit it verbatim as the very first line of your chat reply to the broker** (it looks like `ℹ️ External sale comps: ingested 2026-05-16 17:12 UTC (10 days ago)`). The freshness line tells the broker how current the external snapshot is — it is not optional, never omit or rephrase it.
-   **If `rows` is empty, the response also carries `empty_result`** — read it before you reply (see "Empty result — name the binding filter" below). Never answer a zero-row search with a bare "no comps found".
+   **`property_type` is family-aware and case-insensitive (Worker 0.59.0, lee#532).** Pass the broker's word: `retail` reaches every retail subtype incl. the parenthesized shopping-center values (Neighborhood/Strip/Community/Power Center, malls); `industrial` reaches Industrial + Flex + the internal Flex Warehouse / 100% Warehouse values; `flex` is narrower; `office` is Office only; `medical` reaches Medical, Medical Office and the source typo; `land`, `multifamily`, `specialty`, `hospitality`, `lab`. An exact stored value such as `Retail (Strip Center)` still narrows to that one. Never probe per-subtype to "check coverage" -- one family call is the whole family.
+   **If `rows` is empty, the response also carries `empty_result` AND `miss`** — read `miss.next[0]` first (see "Empty result" below). Never answer a zero-row search with a bare "no comps found".
    **If the response carries `truncated`, the search stopped at the 200-row cap with more rows behind it** (`returned`, `total_available`, `limit`, `ordered_by`, `oldest_returned`, `note`). The rows are the NEWEST ones only — never present them as the answer. Retrieval from here is THIS algorithm and nothing else:
    1. **Readability self-check (every response, capped or not):** as of Worker 0.53.1 every search response carries a top-level `returned` count (`rows.length` as the Worker sent it — distinct from `truncated.returned`, which only appears on capped results). Count the rows you actually parsed out of the text block and compare to `returned`; a text block that ends mid-row or fails to parse as complete JSON is the same signal. If you parsed FEWER rows than `returned`, the CLIENT truncated the visible result — you did not receive those rows, and any cursor advanced past them silently loses comps. Re-issue the SAME call with `limit` set to the number of rows you successfully parsed (floor 25) and use that limit as the WORKING LIMIT for every subsequent page of this ask. Never advance a cursor past rows you did not capture. (Against a pre-0.53.1 Worker the top-level `returned` is absent — fall back to the parse-failure signal alone.)
    2. **Page with the helper, never by hand:** `nxt = next_page_params(params, response)`; call the tool again with `nxt`; repeat until it returns `None` or you have fetched `MAX_PAGES` (5) pages for that params dict. Union every page and every per-county call with `merge_rows(*pages)` (drops the rows that repeat at each page seam).
@@ -98,6 +99,17 @@ covers: it tells you **why** nothing matched, so the broker is never left with s
 - The example above is a **sale**; on a **lease** the size filter is named `min_leased_sf` /
   `max_leased_sf` (the space leased), so tell the broker "the leased size range" cut the
   candidates, never "the building size" (lee#469).
+
+**The server already ran the relaxed asks (Worker 0.59.0, lee#532).** On an empty result the
+response also carries `miss` (the MissReport): the Worker walked a fixed ladder -- dates x2,
+size x1.5, subtype -> family, drop city/zip, drop county, drop dates, drop size, drop type --
+one count per step, and stopped at the first step that found rows. `miss.tried[]` lists every
+step with its row count; `miss.nearest[]` holds up to 3 of that step's newest rows;
+`miss.next[0]` is the exact relaxed call (tool + args) that found them. **Offer `miss.next[0]`
+before anything else** ("Nothing in Sanford; there are 23 industrial sales county-wide in Lee --
+want those?"), and only fall back to the `empty_result` wording below when `miss.next` is empty.
+Never re-run the relaxed call without the broker's yes (Behavioral rule 5); never invent a
+relaxation the ladder did not offer.
 
 **How to reply (after the freshness line):**
 

--- a/plugins/lee-internal-comps/skills/internal-and-external-comps/SKILL.md
+++ b/plugins/lee-internal-comps/skills/internal-and-external-comps/SKILL.md
@@ -77,14 +77,16 @@ external = load_sibling("external-comps")
      snapshot.
    - If one source errors or returns 0 rows, deliver the other with a clear note (e.g.
      "External returned 0 — showing internal only"). Never silently drop a source.
-   - **When external returns 0 rows it also returns `empty_result`** (Worker 0.42.0,
-     lee-and-associates#463): `tightest` names the filter that cut the last candidates and
-     `nearest[]` holds up to 3 comps just past that bound with `miss.by` / `miss.unit`. Put
-     that in the note instead of a bare zero — "External: 0 in the 100k–200k band; the 200k
-     ceiling cut it, nearest is 3241 Pennington Dr at 213,508 sf (13,508 over). Lift it?" —
-     and let the broker decide whether to re-run wider. Never list a near miss as a match.
-     If BOTH sources return 0, the reply is that explanation plus the offer to relax; no
-     empty Excel or PDF.
+   - **`property_type` is family-aware and case-insensitive (Worker 0.59.0, lee#532).** Pass the broker's word: `retail` reaches every retail subtype incl. the parenthesized shopping-center values (Neighborhood/Strip/Community/Power Center, malls); `industrial` reaches Industrial + Flex + the internal Flex Warehouse / 100% Warehouse values; `flex` is narrower; `office` is Office only; `medical` reaches Medical, Medical Office and the source typo; `land`, `multifamily`, `specialty`, `hospitality`, `lab`. An exact stored value such as `Retail (Strip Center)` still narrows to that one. Never probe per-subtype to "check coverage" -- one family call is the whole family. Pass the same family word to the external tool; for the internal SQL leg use the
+     taxonomy table in `internal-comps` (same families, spelled out as `property_type IN (...)`).
+   - **When external returns 0 rows it also returns `empty_result` and `miss`** (Worker 0.59.0,
+     lee#532 on top of lee#463): the Worker already ran the relaxation ladder (dates x2, size
+     x1.5, subtype -> family, drop city/zip, drop county, drop dates, drop size, drop type) and
+     `miss.next[0]` is the first relaxed call that found rows, its newest 3 in `miss.nearest[]`.
+     Offer that hop first -- "External: 0 in Sanford; 23 industrial sales county-wide in Lee.
+     Want those?" -- then `empty_result.tightest` / `nearest[].miss` when `miss.next` is empty.
+     Let the broker decide whether to re-run wider. Never list a near miss as a match. If BOTH
+     sources return 0, the reply is that explanation plus the offer; no empty Excel or PDF.
 5. **Normalize + combine.**
    ```python
    internal_core = [to_core(r, SOURCE_INTERNAL, validated["transaction_type"]) for r in internal_rows]

--- a/plugins/lee-internal-comps/skills/internal-comps/SKILL.md
+++ b/plugins/lee-internal-comps/skills/internal-comps/SKILL.md
@@ -121,6 +121,11 @@ The model does not need to memorize the 365-column schema. The helpers select a 
 | `"lab"` | `'Lab Space'` |
 | `"land"` | `'Land'` |
 
+The typed comps tools (`search_external_*`, `pull_unified_comps`) apply this same family table
+server-side, case-insensitively, since Worker 0.59.0 (lee#532; the table is data in
+`src/tools/comps/property_type.ts`, documented as comps.md D20). For Route A SQL this table is
+still yours to spell out; `describe_table` `conventions` now carries the rule too.
+
 **Industrial outdoor storage / IOS / yard deals:** there is no clean SQL filter — confirmed by the broker. The data fields that would identify them (zoning, yard_sf, yard_type, comp name keywords, notes) are essentially unpopulated. Brokers tag these mentally. If a request mentions IOS, route as `flex` with a `min_acres` filter (broker's recommendation) and surface in the email that this is the closest proxy, not an exact match.
 
 ### Geography registry (V1)

--- a/plugins/lee-internal-comps/skills/lee-flyer-brief/SKILL.md
+++ b/plugins/lee-internal-comps/skills/lee-flyer-brief/SKILL.md
@@ -114,7 +114,7 @@ Batch 2:
 ## Phase 2 — Comp set (present → augment → select → narrate)
 
 1. **Pull** comps matched to deal type and asset class:
-   - Internal: `pull_unified_comps`
+   - Internal: `pull_unified_comps` (Worker 0.59.0: pass `limit` (default 200, max 500) and read `total`/`truncated`; `property_type` takes a family word; dated lease pulls filter on `lease_date`)
    - External: `search_external_sale_comps` / `search_external_lease_comps`
      (use `get_external_comp_detail` for rows the broker wants to inspect;
      `cache_external_rows` for rows that will be used)


### PR DESCRIPTION
## What
Sibling of lee-raleigh-mcp 0.59.0 (lee-and-associates PR for lee#532, T3 of the lee#530 miss-contract program). lee-internal-comps 1.40.0 -> 1.41.0.

- `external-comps` and `internal-and-external-comps`: `property_type` is family-aware and case-insensitive on the Worker -- pass the broker's word (`retail` = the whole retail book incl. the parenthesized shopping-center subtypes; `industrial` reaches flex/warehouse; `medical` is its own family; `office` = Office only); never probe per-subtype. On an empty result read `miss.next[0]` first (the Worker already ran the relaxation ladder: dates x2, size x1.5, subtype -> family, drop city/zip, drop county, drop dates, drop size, drop type -- and found rows at that step; the rows are in `miss.nearest[]`), then fall back to the `empty_result` wording. Never re-run without the broker's yes.
- `internal-comps`: notes the typed tools apply its taxonomy table server-side; Route A SQL still spells it out; `describe_table` conventions carry the rule.
- `lee-flyer-brief`: `pull_unified_comps` pages (`limit`/`offset`/`total`/`truncated`), family words, dated lease pulls filter on `lease_date`.
- Manifests + CHANGELOG.

## Checks
miss-protocol-guidance PASS, connector-auth-guidance PASS, manifest-parity PASS, source-neutrality PASS, no-costar PASS, pytest (plugins/lee-internal-comps/tests) green, pre-commit skill-contract-check PASS on the touched helpers skills.

## Merge order
After lee-raleigh-mcp 0.59.0 is live on prod (migration 0052 + deploy + promote). G26: refresh the connector's tools list before the first Cowork ask (`pull_unified_comps` gained `limit`/`offset`). No frontmatter descriptions changed.

Refs #532 (lee-and-associates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7bwiD8L1atu3ufjHjthmS
