### PR TITLE
lee-branding 1.42.0: the render gate is a command, not a sentence (Refs #169)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lee-internal-comps",
       "source": "./plugins/lee-internal-comps",
       "description": "Lee & Associates broker toolkit. Comps (Lee internal and external, lease and sale) by city, by county, or across the RDU market, as Excel + Lee-branded PDF; demographic and business-key-facts reports; owner, parcel, and mailing-list lookups; traffic counts, labor shed, drive times (reach maps + drive times to named destinations), site infrastructure, development pipeline, and tenants in the market; comp maps and area-amenities map kits; a guided flyer brief; and Lee branding for anything you build, checked against the current brand package on every run. Ask in plain English or use /comps, /internal-comps, /demographic-summary, /owner-lookup and the rest.",
-      "version": "1.41.2"
+      "version": "1.42.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Brokers pick up releases by syncing the marketplace in Cowork (auto-sync toggle 
 via `/plugin update`. `marketplace.json` and `plugins/lee-internal-comps/.claude-plugin/plugin.json`
 carry the same version as of 1.4.0.
 
+## [1.42.0] - 2026-09-04
+
+### Changed
+- **`/lee-branding` cannot render from the bundled files alone (gi-plugins#169).** Two 1.40.0
+  runs on 2026-09-03 delivered Lee flyers with zero `pull_brand_package` rows while the connector
+  was on; the gate was a sentence. New `brand.py`: `call` prints the exact tool call to make,
+  `tokens brand_package.json` validates the saved response (brand_version, token_count matching
+  the colors, usage_rules, logo, notes) and prints the CSS the render is built from; it refuses
+  the bundled `brand-colors.json`. SKILL.md and the skill description now start every render
+  with those two commands. Seven tests pin the gate and the description order (G33).
+
 ## [1.41.2] - 2026-09-03
 
 ### Fixed

--- a/plugins/lee-internal-comps/.claude-plugin/plugin.json
+++ b/plugins/lee-internal-comps/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lee-internal-comps",
   "description": "Lee & Associates broker toolkit. Comps (Lee internal and external, lease and sale) by city, by county, or across the RDU market, as Excel + Lee-branded PDF; demographic and business-key-facts reports; owner, parcel, and mailing-list lookups; traffic counts, labor shed, drive times (reach maps + drive times to named destinations), site infrastructure, development pipeline, and tenants in the market; comp maps and area-amenities map kits; a guided flyer brief; and Lee branding for anything you build, checked against the current brand package on every run. Ask in plain English or use /comps, /internal-comps, /demographic-summary, /owner-lookup and the rest.",
-  "version": "1.41.2",
+  "version": "1.42.0",
   "author": {
     "name": "Grounded Intelligence"
   },

--- a/plugins/lee-internal-comps/skills/lee-branding/SKILL.md
+++ b/plugins/lee-internal-comps/skills/lee-branding/SKILL.md
@@ -14,28 +14,34 @@ brand directly to whatever's being composed.
 ## Before you render anything: pull the brand package
 
 **Every branded deliverable starts with one tool call, and the render cannot start
-without its response.** Two commands, in this order, before any HTML exists:
+without its response.** Two commands, in this order, before any HTML exists. `brand.py`
+sits next to this file; run it by absolute path from wherever your working folder is
+(`python3 <this skill's folder>/brand.py ...`):
 
 ```
-python3 brand.py call
+python3 <this skill's folder>/brand.py call
 ```
 
 prints the exact call: `pull_brand_package({ local_version: "2021.02" })` on the
-lee-raleigh connector (the version comes from the bundled `brand-colors.json`
-(currently `2021.02`); the command reads it, so the literal here is only a convenience). Make that
-call, save the FULL response verbatim as `brand_package.json` in the working folder, then:
+lee-raleigh connector. The version comes from the bundled `brand-colors.json`
+(currently `2021.02`); the command reads it, so you never type it. Make that call and
+save the JSON it returned as `brand_package.json` in the working folder (the raw tool
+result with its `content[].text` wrapper, or the inner object; both are accepted). Then:
 
 ```
-python3 brand.py tokens brand_package.json
+python3 <this skill's folder>/brand.py tokens brand_package.json
 ```
 
 prints the CSS the deliverable is built from: the `:root` color variables, the gradient,
 the type stacks, the `@font-face` block for the bundled WOFFs, the logo path, and the
 `usage_rules` as comments. **Paste that output into the `<style>` of what you render and
-use only those variables for brand color and type.** The command accepts only a
-`pull_brand_package` response; it refuses the bundled `brand-colors.json` and anything
-else, so there is no way to compose a Lee deliverable from the files on disk alone
-(gi-plugins#169: two flyers shipped that way with zero tool rows).
+use only those variables (`--lee-red`, `--lee-charcoal`, `--lee-sans`, ...) for brand
+color and type.** The mechanism: the command checks the shape and invariants only the
+Worker's response has (its version stamp, its usage rules, a token count that equals the
+colors served) and refuses the shipped `brand-colors.json`, so a render needs a payload
+the tool produced. It is a gate against skipping the step, not a cryptographic proof;
+nothing offline could be. (gi-plugins#169: two flyers shipped from the bundled files with
+zero tool rows.)
 
 Render from what the tool returns. It carries the authoritative colors, tints, gradient,
 font stacks, tagline and logo rules, plus `usage_rules` — and those are
@@ -85,55 +91,15 @@ CSS), wire in the three brand signals — **fonts, color, logo** — like this.
 
 ### Fonts — embed the real Avenir Next
 
-The five brand-font WOFFs live in this skill's `fonts/` folder. Embed them with
-`@font-face` so the render uses the real Lee typeface instead of a fallback. Two
-gotchas baked into the block below: the files are the *Cyrillic* cut whose internal
-family names are split, so each face must **declare `font-family: 'Avenir Next'` with
-an explicit weight/style** (don't rely on the embedded name); and they're `woff`
-(v1), so the `format('woff')` hint matters.
-
-```css
-@font-face { font-family:'Avenir Next'; font-weight:400; font-style:normal;
-  src:url('fonts/AvenirNextCyr-Regular.woff') format('woff'); }
-@font-face { font-family:'Avenir Next'; font-weight:400; font-style:italic;
-  src:url('fonts/AvenirNextCyr-Italic.woff') format('woff'); }
-@font-face { font-family:'Avenir Next'; font-weight:500; font-style:normal;
-  src:url('fonts/AvenirNextCyr-Medium.woff') format('woff'); }
-@font-face { font-family:'Avenir Next'; font-weight:500; font-style:italic;
-  src:url('fonts/AvenirNextCyr-MediumItalic.woff') format('woff'); }
-@font-face { font-family:'Avenir Next'; font-weight:700; font-style:normal;
-  src:url('fonts/AvenirNextCyr-Bold.woff') format('woff'); }
-
-/* Minion Pro — accent/headline serif (bundled as WOFF, converted from the licensed OTFs in fonts/minion-pro/) */
-@font-face { font-family:'Minion Pro'; font-weight:400; font-style:normal;
-  src:url('fonts/MinionPro-Regular.woff') format('woff'); }
-@font-face { font-family:'Minion Pro'; font-weight:400; font-style:italic;
-  src:url('fonts/MinionPro-It.woff') format('woff'); }
-@font-face { font-family:'Minion Pro'; font-weight:500; font-style:normal;
-  src:url('fonts/MinionPro-Medium.woff') format('woff'); }
-@font-face { font-family:'Minion Pro'; font-weight:500; font-style:italic;
-  src:url('fonts/MinionPro-MediumIt.woff') format('woff'); }
-@font-face { font-family:'Minion Pro'; font-weight:600; font-style:normal;
-  src:url('fonts/MinionPro-Semibold.woff') format('woff'); }
-@font-face { font-family:'Minion Pro'; font-weight:600; font-style:italic;
-  src:url('fonts/MinionPro-SemiboldIt.woff') format('woff'); }
-@font-face { font-family:'Minion Pro'; font-weight:700; font-style:normal;
-  src:url('fonts/MinionPro-Bold.woff') format('woff'); }
-@font-face { font-family:'Minion Pro'; font-weight:700; font-style:italic;
-  src:url('fonts/MinionPro-BoldIt.woff') format('woff'); }
-
-:root { --sans:'Avenir Next','Nunito Sans',Arial,Tahoma,sans-serif;
-        --serif:'Minion Pro',Georgia,serif; }
-body { font-family:var(--sans); }
-```
-
-The `url('fonts/...')` paths resolve when the HTML file you render sits in this skill
-folder (write your temp HTML here, or point `url()` at the absolute path to these
-files). If you're rendering somewhere the relative path won't resolve, base64-embed
-the WOFFs into the `src:` instead — the sandbox has no network, so a remote font URL
-will silently fall back. **Minion Pro is now bundled** (WOFF in `fonts/`, converted from
-the licensed Adobe OTFs in `fonts/minion-pro/`); use it for accent/headline serif.
-Georgia stays the sanctioned fallback if a weight is missing — don't invent a substitute.
+The `@font-face` block `brand.py tokens` printed already declares every bundled face
+with an absolute path into this skill's `fonts/` folder (five Avenir Next WOFFs, eight
+Minion Pro WOFFs). Two gotchas are why it is generated and not hand-written: the files
+are the Cyrillic cut whose internal family names are split, so each face is declared as
+`'Avenir Next'` with an explicit weight/style, and they are `woff` (v1), so the
+`format('woff')` hint matters. If the renderer cannot read files by path, base64-embed
+the WOFFs into the `src:` instead; the sandbox has no network, so a remote font URL
+silently falls back. Georgia stays the sanctioned fallback if a weight is missing; don't
+invent a substitute.
 
 **Type hierarchy:** Avenir Next Bold (700) for headings, Medium (500) for subheads and
 emphasis, Regular (400) for body. Optional Minion Pro / Georgia serif for a headline or
@@ -157,8 +123,7 @@ load-bearing rules, which also come back as `usage_rules`:
   infographics, and diagrams only**, used sparingly — never a document's primary color.
   Green and Mint never appear together; a Merlot/Bright-Red pairing never combines with
   Green or Mint.
-- The **icon gradient** (`linear-gradient(145deg,#CD1442 0%,#98002E 65%,#4E131E 100%)`,
-  in `brand-colors.json`) is available for a bold signature block when a flat red isn't
+- The **icon gradient** (`--lee-gradient`, from the tool's response) is available for a bold signature block when a flat red isn't
   enough — use it deliberately, not as default chrome.
 
 ### Logo — place it, never touch it
@@ -191,18 +156,19 @@ invent a brand rule that isn't in the guidelines.**
 Separate, less-common path — this is marketing-team-shaped work, not the day-to-day
 broker riff. When the **marketing team** wants the Lee brand set up **once** in Claude
 Design so every design across the org inherits it automatically, or a broker explicitly
-asks to "set up the shared Lee design system," **call `pull_brand_package` first, the
-same as any render** — this path matters MORE, not less, because a stale palette
-uploaded as the org-wide design system propagates to every Lee design indefinitely.
-Upload the values the tool returns; if they differ from the bundled file, the tool's
-response wins and you say so. If the call cannot be completed, stop here too.
+asks to "set up the shared Lee design system," **run `python3 <this skill's folder>/brand.py call`,
+make the call, and `brand.py tokens brand_package.json`, the same as any render** — this
+path matters MORE, not less, because a stale palette uploaded as the org-wide design
+system propagates to every Lee design indefinitely. Paste the `:root` values the command
+printed when Claude Design asks for the palette; if they differ from the bundled file,
+the tool's response wins and you say so. If the call cannot be completed, stop here too.
 
 Then walk them through the bundled `claude-design-setup.md` and stage these files for
 upload into Claude Design's design-system onboarding: `lee-associates-brand-guidelines.md`,
 `lee_logo.svg` (+ `lee_logo.png` backup), `brand-colors.json`, and the bundled WOFFs in
-`fonts/` (five Avenir Next + eight Minion Pro). **If the tool reported a divergence, do
-NOT upload `brand-colors.json` — paste the tool's values when Claude Design asks for the
-palette.** Handing it the stale file is the one outcome gating this path was meant to
+`fonts/` (five Avenir Next + eight Minion Pro). **Upload `brand-colors.json` only for its print columns (PMS / CMYK / RGB);
+the screen palette is the `:root` block from `brand.py tokens`, and if the tool reported
+a divergence, do NOT upload the file at all.** Handing it the stale file is the one outcome gating this path was meant to
 stop. That's a one-time org setup; the primary path above is what you reach for on an
 individual deliverable.
 

--- a/plugins/lee-internal-comps/skills/lee-branding/SKILL.md
+++ b/plugins/lee-internal-comps/skills/lee-branding/SKILL.md
@@ -21,8 +21,8 @@ python3 brand.py call
 ```
 
 prints the exact call: `pull_brand_package({ local_version: "2021.02" })` on the
-lee-raleigh connector (the version comes from the bundled `brand-colors.json`, currently
-`2021.02`; the command reads it, so the literal here is only a convenience). Make that
+lee-raleigh connector (the version comes from the bundled `brand-colors.json`
+(currently `2021.02`); the command reads it, so the literal here is only a convenience). Make that
 call, save the FULL response verbatim as `brand_package.json` in the working folder, then:
 
 ```

--- a/plugins/lee-internal-comps/skills/lee-branding/SKILL.md
+++ b/plugins/lee-internal-comps/skills/lee-branding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lee-branding
-description: Make anything you're building for a Lee & Associates broker look on-brand — apply the Lee logo, the brand red, and the Avenir Next fonts to a flyer, one-pager, deck, chart, PDF, or email header right here in the chat. Use when a broker says "make me a PDF of this and make it look good," "brand this," "make this on-brand for Lee," "add the Lee logo," "use our brand colors," or is riffing on a deliverable and wants it polished to the Lee look. Ships Lee's official brand package on disk (logo, colors, guidelines, fonts) so you apply it without asking the broker for files, and checks that bundled package against the current one on every run so a deliverable never goes out against stale brand values. Also covers the one-time Claude Design setup for the marketing team.
+description: Make anything you're building for a Lee & Associates broker look on-brand. Starts every render with the pull_brand_package call on the lee-raleigh connector and a gate command that turns its response into the CSS the deliverable uses; then applies the Lee logo, the brand red, and the Avenir Next fonts to a flyer, one-pager, deck, chart, PDF, or email header right here in the chat. Use when a broker says "make me a PDF of this and make it look good," "brand this," "make this on-brand for Lee," "add the Lee logo," "use our brand colors," or is riffing on a deliverable and wants it polished to the Lee look. The logo and fonts are bundled on disk; the VALUES come from the tool on every run, so a deliverable never goes out against stale brand values and never goes out without the call. Also covers the one-time Claude Design setup for the marketing team.
 ---
 
 # Lee & Associates Branding
@@ -13,15 +13,31 @@ brand directly to whatever's being composed.
 
 ## Before you render anything: pull the brand package
 
-**Every branded deliverable starts with one tool call.** Call the lee-raleigh MCP
-tool `pull_brand_package`, passing the `version` value from the bundled
-`brand-colors.json` (currently `2021.02`):
+**Every branded deliverable starts with one tool call, and the render cannot start
+without its response.** Two commands, in this order, before any HTML exists:
 
 ```
-pull_brand_package({ local_version: "2021.02" })
+python3 brand.py call
 ```
 
-Render from what it returns. It carries the authoritative colors, tints, gradient,
+prints the exact call: `pull_brand_package({ local_version: "2021.02" })` on the
+lee-raleigh connector (the version comes from the bundled `brand-colors.json`, currently
+`2021.02`; the command reads it, so the literal here is only a convenience). Make that
+call, save the FULL response verbatim as `brand_package.json` in the working folder, then:
+
+```
+python3 brand.py tokens brand_package.json
+```
+
+prints the CSS the deliverable is built from: the `:root` color variables, the gradient,
+the type stacks, the `@font-face` block for the bundled WOFFs, the logo path, and the
+`usage_rules` as comments. **Paste that output into the `<style>` of what you render and
+use only those variables for brand color and type.** The command accepts only a
+`pull_brand_package` response; it refuses the bundled `brand-colors.json` and anything
+else, so there is no way to compose a Lee deliverable from the files on disk alone
+(gi-plugins#169: two flyers shipped that way with zero tool rows).
+
+Render from what the tool returns. It carries the authoritative colors, tints, gradient,
 font stacks, tagline and logo rules, plus `usage_rules` — and those are
 constraints, not notes (they are what tells you charcoal, never slate, carries
 text under 10pt). It also answers the one question this skill cannot answer on its
@@ -30,9 +46,10 @@ own: whether the brand package bundled with this plugin is still the current one
 two copies have diverged.
 
 **If the call cannot be completed, stop and say so. Do not fall back to the
-bundled files.** The fonts and the logo on disk are still there, but a deliverable
-built without this call is unverified against Lee's current brand, and going ahead
-anyway hides a broker whose plugin was never fully set up.
+bundled files.** The fonts and the logo on disk are still there, but `brand.py tokens`
+will not run without the response, and a deliverable built without this call is
+unverified against Lee's current brand; going ahead anyway hides a broker whose plugin
+was never fully set up.
 
 Which failure you have decides what you say. Work through these in order:
 
@@ -124,8 +141,9 @@ pull-quote accent.
 
 ### Color — Lee Red is an accent, not a wash
 
-Pull exact values from the `colors` in the `pull_brand_package` response (the bundled
-`brand-colors.json` is the version you sent it, not the source you render from). The
+Use the `--lee-*` variables `brand.py tokens` printed from the `pull_brand_package`
+response (the bundled `brand-colors.json` is the version you sent it, not the source you
+render from). The
 load-bearing rules, which also come back as `usage_rules`:
 
 - **Red `#98002E`** (PMS 202) is the signature accent — rules, a header bar, a key
@@ -192,6 +210,9 @@ individual deliverable.
 
 - `SKILL.md` — this file. Calls the `pull_brand_package` MCP tool on `lee-raleigh`
   before rendering anything.
+- `brand.py` — the render gate: `call` prints the tool call to make; `tokens
+  brand_package.json` validates the saved response and prints the CSS the render uses.
+  Refuses the bundled `brand-colors.json`.
 - `brand-colors.json` — machine-readable color tokens (HEX / PMS / CMYK / RGB, tints, the
   icon gradient). Its `version` is what you send as `local_version`; render from the
   tool's response, not from this file. Print-only values (PMS / CMYK / RGB) live here

--- a/plugins/lee-internal-comps/skills/lee-branding/brand.py
+++ b/plugins/lee-internal-comps/skills/lee-branding/brand.py
@@ -37,6 +37,14 @@ SAVE_AS = "brand_package.json"
 # brand_version / token_count / usage_rules / logo / notes), which is what lets the gate
 # tell the two apart without a shared secret.
 REQUIRED = ("brand_version", "local_package_current", "colors", "usage_rules", "logo", "token_count", "notes")
+PRIMARY_NAMES = ("red", "slate", "charcoal", "white")  # the load-bearing names usage_rules and body{} rely on
+DEFAULT_SANS = "'Avenir Next', 'Nunito Sans', Arial, Tahoma, sans-serif"
+DEFAULT_SERIF = "'Minion Pro', Georgia, serif"
+NOT_A_RESPONSE = (
+    "not a pull_brand_package response. Run `python3 " + os.path.join(HERE, "brand.py") +
+    " call`, make that call on the lee-raleigh connector, save the JSON it returned as "
+    + SAVE_AS + ", and pass that file. The bundled files cannot feed this command."
+)
 
 FONT_FACES = [
     ("Avenir Next", 400, "normal", "AvenirNextCyr-Regular.woff"),
@@ -69,63 +77,83 @@ def bundled_version() -> str:
         return json.load(fh)["version"]
 
 
+def unwrap(payload: Any) -> Any:
+    """Accept the raw MCP tool result the session saves verbatim
+    ({content:[{type:"text", text:"<json>"}]}) or a bare JSON string, as well as the
+    inner object itself (no unwrap cliff, G33)."""
+    for _ in range(3):
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+                continue
+            except ValueError:
+                return payload
+        if isinstance(payload, dict) and "content" in payload and "brand_version" not in payload:
+            items = payload.get("content") or []
+            texts = [i.get("text") for i in items if isinstance(i, dict) and i.get("type") == "text"]
+            if texts:
+                payload = texts[0]
+                continue
+        if isinstance(payload, dict) and "result" in payload and "brand_version" not in payload:
+            payload = payload["result"]
+            continue
+        break
+    return payload
+
+
 def validate_response(payload: Any) -> dict:
-    """Return the payload if it is a pull_brand_package response; raise otherwise."""
+    """Return the payload if it is a pull_brand_package response; raise otherwise.
+    The check is shape and invariants (the fields only the Worker returns, and a
+    token_count that equals the colors served); it refuses the shipped file and
+    anything hand-assembled from it, which is the failure mode being closed. It is
+    not a cryptographic proof; nothing offline could be without a shared secret."""
     if not isinstance(payload, dict):
-        raise NotAToolResponse("the file is not a JSON object")
-    missing = [k for k in REQUIRED if k not in payload]
-    if "version" in payload and "brand_version" not in payload:
-        raise NotAToolResponse(
-            "this is the bundled brand-colors.json (it has `version`, not `brand_version`), "
-            "not a pull_brand_package response. Call the tool first (python3 brand.py call), "
-            f"save its response as {SAVE_AS}, and pass that file."
-        )
-    if missing:
-        raise NotAToolResponse(
-            "not a pull_brand_package response: missing " + ", ".join(missing) +
-            ". Only the tool's response carries these; the bundled files cannot feed this command. "
-            "Call the tool first (python3 brand.py call)."
-        )
+        raise NotAToolResponse(NOT_A_RESPONSE)
+    if any(k not in payload for k in REQUIRED):
+        raise NotAToolResponse(NOT_A_RESPONSE)
     colors = payload["colors"]
     if not isinstance(colors, dict) or not colors:
-        raise NotAToolResponse("colors must be a non-empty object of color groups")
+        raise NotAToolResponse(NOT_A_RESPONSE)
     n = 0
     for group, entries in colors.items():
         if not isinstance(entries, dict):
-            raise NotAToolResponse(f"colors.{group} must be an object of name -> hex")
+            raise NotAToolResponse(NOT_A_RESPONSE)
         for name, hexv in entries.items():
             if not (isinstance(hexv, str) and hexv.startswith("#") and len(hexv) in (4, 7)):
-                raise NotAToolResponse(
-                    f"colors.{group}.{name} is {hexv!r}, not a hex string; the bundled file's "
-                    "{hex, pms, rgb, cmyk} objects are not the tool's shape"
-                )
+                raise NotAToolResponse(NOT_A_RESPONSE)
             n += 1
+    primary = colors.get("primary") or {}
+    if any(k not in primary for k in PRIMARY_NAMES):
+        raise NotAToolResponse(NOT_A_RESPONSE)
     if payload["token_count"] != n:
         raise NotAToolResponse(
             f"token_count {payload['token_count']} does not match the {n} colors in the payload; "
             "this is not the response the Worker sent"
         )
     if not isinstance(payload["usage_rules"], dict) or not payload["usage_rules"]:
-        raise NotAToolResponse("usage_rules is empty; not the tool's response")
+        raise NotAToolResponse(NOT_A_RESPONSE)
     if not isinstance(payload["notes"], list):
-        raise NotAToolResponse("notes must be a list")
+        raise NotAToolResponse(NOT_A_RESPONSE)
     return payload
 
 
 def render_css(payload: dict) -> str:
     out: list[str] = []
-    if payload.get("local_package_current") is False or payload.get("notes"):
-        for note in payload.get("notes") or ["Brand package mismatch: render from these values and tell your GI contact."]:
-            out.append(f"/* NOTE FROM pull_brand_package: {note} */")
+    notes = list(payload.get("notes") or [])
+    if payload.get("local_package_current") is False and not notes:
+        notes = ["Brand package mismatch: render from these values and tell your Grounded Intelligence contact the two copies have diverged."]
+    for note in notes:
+        out.append(f"/* NOTE FROM pull_brand_package: {note} */")
     out.append(f"/* Lee & Associates brand, served by pull_brand_package (brand_version {payload['brand_version']}). */")
     out.append("/* Render from THESE values. usage_rules (constraints, not notes): */")
     for k, v in payload["usage_rules"].items():
         out.append(f"/*   {k}: {v} */")
     logo = payload.get("logo") or {}
+    prohibited = ", ".join(logo.get("prohibited") or [])
     out.append(
         f"/* logo: lee_logo.svg (or lee_logo.png); min width {logo.get('min_width_in', 1.125)} in; "
-        f"clear space {logo.get('clear_space', 'equal to the height of the icon on all sides')}; "
-        f"never {', '.join(logo.get('prohibited', []))}. Must appear at least once. */"
+        f"clear space {logo.get('clear_space', 'equal to the height of the icon on all sides')}"
+        + (f"; never {prohibited}" if prohibited else "") + ". Must appear at least once. */"
     )
     out.append("")
     for face, weight, style, fname in FONT_FACES:
@@ -142,10 +170,10 @@ def render_css(payload: dict) -> str:
     if grad:
         out.append(f"  --lee-gradient: {grad};")
     typ = payload.get("type") or {}
-    out.append(f"  --sans: {typ.get('stack_sans', chr(39) + 'Avenir Next' + chr(39) + ', ' + chr(39) + 'Nunito Sans' + chr(39) + ', Arial, Tahoma, sans-serif')};")
-    out.append(f"  --serif: {typ.get('stack_serif', chr(39) + 'Minion Pro' + chr(39) + ', Georgia, serif')};")
+    out.append(f"  --lee-sans: {typ.get('stack_sans', DEFAULT_SANS)};")
+    out.append(f"  --lee-serif: {typ.get('stack_serif', DEFAULT_SERIF)};")
     out.append("}")
-    out.append("body { font-family: var(--sans); color: var(--lee-charcoal); background: var(--lee-white); }")
+    out.append("body { font-family: var(--lee-sans); color: var(--lee-charcoal); background: var(--lee-white); }")
     out.append(f"/* logo file: {os.path.join(HERE, 'lee_logo.svg')} */")
     tagline = payload.get("tagline")
     if tagline:
@@ -175,7 +203,7 @@ def main(argv: list[str]) -> int:
     except Exception as e:
         return _fail(f"could not read {path}: {e}. Save the pull_brand_package response as {SAVE_AS} first.")
     try:
-        payload = validate_response(payload)
+        payload = validate_response(unwrap(payload))
     except NotAToolResponse as e:
         return _fail(str(e))
     sys.stdout.write(render_css(payload))

--- a/plugins/lee-internal-comps/skills/lee-branding/brand.py
+++ b/plugins/lee-internal-comps/skills/lee-branding/brand.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+brand.py — the lee-branding render gate (gi-plugins#169).
+
+Two commands, no dependencies beyond the standard library:
+
+  python3 brand.py call
+      Prints the exact pull_brand_package call to make (tool, arguments, and the
+      filename to save the response under). Run this first, every render.
+
+  python3 brand.py tokens brand_package.json
+      Validates that the file is a pull_brand_package RESPONSE and prints the CSS the
+      render uses: the :root color variables, the gradient, the type stacks, the
+      @font-face block for the bundled WOFFs, the logo path, and the usage rules as
+      comments. It REFUSES the bundled brand-colors.json (and anything else that is not
+      the tool's response), so a deliverable cannot be composed from local files alone.
+
+Why a command and not a sentence: on 2026-09-03 two Sonnet sessions rendered Lee flyers
+with zero pull_brand_package rows while the connector was on. The instruction was prose;
+prose gets read as description (gotcha registry G33). The values the HTML needs now come
+out of this command, and this command only accepts what the tool returned.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUNDLED = os.path.join(HERE, "brand-colors.json")
+SAVE_AS = "brand_package.json"
+
+# Fields only the Worker's response carries. The bundled brand-colors.json has none of
+# these (its color entries are {hex, pms, rgb, cmyk} objects, it carries no
+# brand_version / token_count / usage_rules / logo / notes), which is what lets the gate
+# tell the two apart without a shared secret.
+REQUIRED = ("brand_version", "local_package_current", "colors", "usage_rules", "logo", "token_count", "notes")
+
+FONT_FACES = [
+    ("Avenir Next", 400, "normal", "AvenirNextCyr-Regular.woff"),
+    ("Avenir Next", 400, "italic", "AvenirNextCyr-Italic.woff"),
+    ("Avenir Next", 500, "normal", "AvenirNextCyr-Medium.woff"),
+    ("Avenir Next", 500, "italic", "AvenirNextCyr-MediumItalic.woff"),
+    ("Avenir Next", 700, "normal", "AvenirNextCyr-Bold.woff"),
+    ("Minion Pro", 400, "normal", "MinionPro-Regular.woff"),
+    ("Minion Pro", 400, "italic", "MinionPro-It.woff"),
+    ("Minion Pro", 500, "normal", "MinionPro-Medium.woff"),
+    ("Minion Pro", 500, "italic", "MinionPro-MediumIt.woff"),
+    ("Minion Pro", 600, "normal", "MinionPro-Semibold.woff"),
+    ("Minion Pro", 600, "italic", "MinionPro-SemiboldIt.woff"),
+    ("Minion Pro", 700, "normal", "MinionPro-Bold.woff"),
+    ("Minion Pro", 700, "italic", "MinionPro-BoldIt.woff"),
+]
+
+
+class NotAToolResponse(ValueError):
+    pass
+
+
+def _fail(msg: str) -> int:
+    print(json.dumps({"ok": False, "error": msg}))
+    return 1
+
+
+def bundled_version() -> str:
+    with open(BUNDLED) as fh:
+        return json.load(fh)["version"]
+
+
+def validate_response(payload: Any) -> dict:
+    """Return the payload if it is a pull_brand_package response; raise otherwise."""
+    if not isinstance(payload, dict):
+        raise NotAToolResponse("the file is not a JSON object")
+    missing = [k for k in REQUIRED if k not in payload]
+    if "version" in payload and "brand_version" not in payload:
+        raise NotAToolResponse(
+            "this is the bundled brand-colors.json (it has `version`, not `brand_version`), "
+            "not a pull_brand_package response. Call the tool first (python3 brand.py call), "
+            f"save its response as {SAVE_AS}, and pass that file."
+        )
+    if missing:
+        raise NotAToolResponse(
+            "not a pull_brand_package response: missing " + ", ".join(missing) +
+            ". Only the tool's response carries these; the bundled files cannot feed this command. "
+            "Call the tool first (python3 brand.py call)."
+        )
+    colors = payload["colors"]
+    if not isinstance(colors, dict) or not colors:
+        raise NotAToolResponse("colors must be a non-empty object of color groups")
+    n = 0
+    for group, entries in colors.items():
+        if not isinstance(entries, dict):
+            raise NotAToolResponse(f"colors.{group} must be an object of name -> hex")
+        for name, hexv in entries.items():
+            if not (isinstance(hexv, str) and hexv.startswith("#") and len(hexv) in (4, 7)):
+                raise NotAToolResponse(
+                    f"colors.{group}.{name} is {hexv!r}, not a hex string; the bundled file's "
+                    "{hex, pms, rgb, cmyk} objects are not the tool's shape"
+                )
+            n += 1
+    if payload["token_count"] != n:
+        raise NotAToolResponse(
+            f"token_count {payload['token_count']} does not match the {n} colors in the payload; "
+            "this is not the response the Worker sent"
+        )
+    if not isinstance(payload["usage_rules"], dict) or not payload["usage_rules"]:
+        raise NotAToolResponse("usage_rules is empty; not the tool's response")
+    if not isinstance(payload["notes"], list):
+        raise NotAToolResponse("notes must be a list")
+    return payload
+
+
+def render_css(payload: dict) -> str:
+    out: list[str] = []
+    if payload.get("local_package_current") is False or payload.get("notes"):
+        for note in payload.get("notes") or ["Brand package mismatch: render from these values and tell your GI contact."]:
+            out.append(f"/* NOTE FROM pull_brand_package: {note} */")
+    out.append(f"/* Lee & Associates brand, served by pull_brand_package (brand_version {payload['brand_version']}). */")
+    out.append("/* Render from THESE values. usage_rules (constraints, not notes): */")
+    for k, v in payload["usage_rules"].items():
+        out.append(f"/*   {k}: {v} */")
+    logo = payload.get("logo") or {}
+    out.append(
+        f"/* logo: lee_logo.svg (or lee_logo.png); min width {logo.get('min_width_in', 1.125)} in; "
+        f"clear space {logo.get('clear_space', 'equal to the height of the icon on all sides')}; "
+        f"never {', '.join(logo.get('prohibited', []))}. Must appear at least once. */"
+    )
+    out.append("")
+    for face, weight, style, fname in FONT_FACES:
+        out.append(
+            f"@font-face {{ font-family:'{face}'; font-weight:{weight}; font-style:{style}; "
+            f"src:url('{os.path.join(HERE, 'fonts', fname)}') format('woff'); }}"
+        )
+    out.append("")
+    out.append(":root {")
+    for group, entries in payload["colors"].items():
+        for name, hexv in entries.items():
+            out.append(f"  --lee-{name.replace('_', '-')}: {hexv};")
+    grad = (payload.get("gradient") or {}).get("css")
+    if grad:
+        out.append(f"  --lee-gradient: {grad};")
+    typ = payload.get("type") or {}
+    out.append(f"  --sans: {typ.get('stack_sans', chr(39) + 'Avenir Next' + chr(39) + ', ' + chr(39) + 'Nunito Sans' + chr(39) + ', Arial, Tahoma, sans-serif')};")
+    out.append(f"  --serif: {typ.get('stack_serif', chr(39) + 'Minion Pro' + chr(39) + ', Georgia, serif')};")
+    out.append("}")
+    out.append("body { font-family: var(--sans); color: var(--lee-charcoal); background: var(--lee-white); }")
+    out.append(f"/* logo file: {os.path.join(HERE, 'lee_logo.svg')} */")
+    tagline = payload.get("tagline")
+    if tagline:
+        out.append(f"/* tagline: {tagline} */")
+    return "\n".join(out) + "\n"
+
+
+def main(argv: list[str]) -> int:
+    if not argv or argv[0] not in ("call", "tokens"):
+        print("usage: python3 brand.py call | python3 brand.py tokens brand_package.json", file=sys.stderr)
+        return 2
+    if argv[0] == "call":
+        print(json.dumps({
+            "tool": "pull_brand_package",
+            "connector": "lee-raleigh",
+            "arguments": {"local_version": bundled_version()},
+            "save_as": SAVE_AS,
+            "then": f"python3 brand.py tokens {SAVE_AS}",
+        }, indent=2))
+        return 0
+    if len(argv) < 2:
+        return _fail(f"usage: python3 brand.py tokens {SAVE_AS}")
+    path = argv[1]
+    try:
+        with open(path) as fh:
+            payload = json.load(fh)
+    except Exception as e:
+        return _fail(f"could not read {path}: {e}. Save the pull_brand_package response as {SAVE_AS} first.")
+    try:
+        payload = validate_response(payload)
+    except NotAToolResponse as e:
+        return _fail(str(e))
+    sys.stdout.write(render_css(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/lee-internal-comps/skills/lee-branding/claude-design-setup.md
+++ b/plugins/lee-internal-comps/skills/lee-branding/claude-design-setup.md
@@ -50,7 +50,7 @@ and feeding it the brand files below.
    - **Brand guidelines:** upload `lee-associates-brand-guidelines.md`, the document Claude
      reads to learn the red, the fonts, the logo do's and don'ts, and the photography style.
    - **Logo:** add `lee_logo.svg` (SVG preferred; add `lee_logo.png` as a backup).
-   - **Colors:** upload `brand-colors.json`, or paste the hex codes when Claude asks for your
+   - **Colors:** paste the `:root` hex values `brand.py tokens` printed from the live `pull_brand_package` response (upload `brand-colors.json` only for the print PMS / CMYK columns), or paste the hex codes when Claude asks for your
      palette.
    - **Fonts:** add the WOFF files in the `fonts/` folder — Avenir Next (primary typeface)
      and Minion Pro (accent/headline serif) — so Claude renders the real brand type instead

--- a/plugins/lee-internal-comps/tests/test_lee_branding_gate.py
+++ b/plugins/lee-internal-comps/tests/test_lee_branding_gate.py
@@ -82,7 +82,7 @@ def test_tokens_rejects_a_payload_missing_the_fields_only_the_tool_returns(tmp_p
     p.write_text(json.dumps(r))
     out = _run("tokens", str(p))
     assert out.returncode != 0
-    assert "brand_version" in json.loads(out.stdout)["error"]
+    assert "brand.py call" in json.loads(out.stdout)["error"]  # no key enumeration (review #175)
 
 
 def test_tokens_surfaces_a_stale_bundle_note_at_the_top_of_the_css(tmp_path):
@@ -111,3 +111,75 @@ def test_skill_md_drives_the_gate_command_and_names_the_tool_call_first():
     # the router contract (G12) names the tool call before it advertises the bundled assets
     assert desc.index("pull_brand_package") < desc.index("bundle")
     assert "without asking the broker for files" not in desc
+
+
+# --- review round 1 (PR #175) -------------------------------------------------
+
+def test_tokens_unwraps_the_raw_tool_result_the_session_saves_verbatim(tmp_path):
+    # the MCP client hands the session {content:[{type:"text", text:"<json>"}]}
+    wrapped = {"content": [{"type": "text", "text": json.dumps(_response())}]}
+    p = tmp_path / "brand_package.json"
+    p.write_text(json.dumps(wrapped))
+    out = _run("tokens", str(p))
+    assert out.returncode == 0, out.stdout
+    assert "--lee-red: #98002E" in out.stdout
+
+
+def test_tokens_unwraps_a_bare_json_string(tmp_path):
+    p = tmp_path / "brand_package.json"
+    p.write_text(json.dumps(json.dumps(_response())))
+    out = _run("tokens", str(p))
+    assert out.returncode == 0, out.stdout
+
+
+def test_refusal_does_not_enumerate_the_missing_keys():
+    out = _run("tokens", str(SKILL / "brand-colors.json"))
+    err = json.loads(out.stdout)["error"]
+    for key in ("token_count", "usage_rules", "brand_version"):
+        assert key not in err
+    assert "brand.py call" in err
+
+
+def test_tokens_requires_the_four_primary_colors(tmp_path):
+    r = _response()
+    r["colors"] = {"accent": {"merlot": "#4E131E"}}
+    r["token_count"] = 1
+    p = tmp_path / "brand_package.json"
+    p.write_text(json.dumps(r))
+    out = _run("tokens", str(p))
+    assert out.returncode != 0
+
+
+def test_css_names_and_type_variables(tmp_path):
+    p = tmp_path / "brand_package.json"
+    p.write_text(json.dumps(_response()))
+    css = _run("tokens", str(p)).stdout
+    assert "--lee-bright-red: #CD1442" in css
+    assert "--lee-sans:" in css and "--lee-serif:" in css
+    assert "never ." not in css
+
+
+def test_empty_prohibited_list_does_not_print_a_dangling_never(tmp_path):
+    r = _response(); r["logo"]["prohibited"] = []
+    p = tmp_path / "brand_package.json"; p.write_text(json.dumps(r))
+    css = _run("tokens", str(p)).stdout
+    assert "never ." not in css
+
+
+def test_mismatch_note_is_the_first_line(tmp_path):
+    p = tmp_path / "brand_package.json"
+    p.write_text(json.dumps(_response(local_package_current=False, local_version="2020.01",
+                                      notes=["Brand package mismatch: yours is 2020.01, ours is 2021.02."])))
+    assert "Brand package mismatch" in _run("tokens", str(p)).stdout.splitlines()[0]
+
+
+def test_tokens_without_an_argument_prints_json_and_fails():
+    out = _run("tokens")
+    assert out.returncode != 0 and "error" in json.loads(out.stdout)
+
+
+def test_skill_md_no_longer_ships_a_paste_ready_stylesheet_from_bundled_files():
+    text = (SKILL / "SKILL.md").read_text()
+    assert "src:url('fonts/AvenirNextCyr-Regular.woff')" not in text
+    assert "brand.py call" in text.split("## Edge case")[1]  # the Claude Design path uses the gate too
+    assert "this skill's folder" in text or "absolute path" in text

--- a/plugins/lee-internal-comps/tests/test_lee_branding_gate.py
+++ b/plugins/lee-internal-comps/tests/test_lee_branding_gate.py
@@ -1,0 +1,113 @@
+"""gi-plugins#169: the lee-branding render cannot proceed from the bundled files alone.
+
+Bonner's two 1.40.0 Sonnet runs (2026-09-03) delivered Lee-branded flyers with zero
+`pull_brand_package` rows in prod audit_log, the second in a task that provably had the
+connector on. The gate was prose ("Every branded deliverable starts with one tool
+call"). G33: prose-only mandatory steps get skipped. The structural gate: the CSS the
+render needs comes from `python3 brand.py tokens brand_package.json`, and that command
+accepts only a pull_brand_package RESPONSE (brand_version, token_count, usage_rules,
+logo, notes), never the bundled brand-colors.json.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SKILL = Path(__file__).parent.parent / "skills" / "lee-branding"
+BRAND_PY = SKILL / "brand.py"
+
+
+def _response(**over):
+    colors = {
+        "primary": {"red": "#98002E", "slate": "#7E8083", "charcoal": "#303C42", "white": "#FFFFFF"},
+        "secondary": {"navy": "#003146", "sky": "#009AD9", "frost": "#A9C3CB"},
+        "accent": {"merlot": "#4E131E", "bright_red": "#CD1442", "green": "#8A941E", "mint": "#6FC9C4"},
+    }
+    r = {
+        "brand_version": "2021.02",
+        "local_package_current": True,
+        "local_version": "2021.02",
+        "tagline": "LOCAL EXPERTISE. INTERNATIONAL REACH. WORLD CLASS.",
+        "colors": colors,
+        "tints": {"primary_pct": [80, 60, 40]},
+        "gradient": {"css": "linear-gradient(145deg, #CD1442 0%, #98002E 65%, #4E131E 100%)"},
+        "type": {"stack_sans": "'Avenir Next', 'Nunito Sans', Arial, Tahoma, sans-serif", "stack_serif": "'Minion Pro', Georgia, serif"},
+        "usage_rules": {"small_text_under_10pt": "Use charcoal (#303C42) instead of slate (#7E8083) for legibility."},
+        "logo": {"min_width_in": 1.125, "clear_space": "equal to the height of the icon on all sides", "prohibited": ["redraw"]},
+        "token_count": 11,
+        "notes": [],
+    }
+    r.update(over)
+    return r
+
+
+def _run(*args, cwd=None):
+    return subprocess.run([sys.executable, str(BRAND_PY), *args], capture_output=True, text=True, cwd=cwd or SKILL)
+
+
+def test_tokens_refuses_the_bundled_brand_colors_json():
+    out = _run("tokens", str(SKILL / "brand-colors.json"))
+    assert out.returncode != 0
+    err = json.loads(out.stdout)["error"]
+    assert "pull_brand_package" in err and "bundled" in err
+
+
+def test_tokens_accepts_a_pull_brand_package_response(tmp_path):
+    p = tmp_path / "brand_package.json"
+    p.write_text(json.dumps(_response()))
+    out = _run("tokens", str(p))
+    assert out.returncode == 0, out.stdout + out.stderr
+    css = out.stdout
+    assert "--lee-red: #98002E" in css
+    assert "--lee-charcoal: #303C42" in css
+    assert "@font-face" in css and "AvenirNextCyr-Bold.woff" in css
+    assert "--lee-gradient:" in css
+    assert "lee_logo.svg" in css
+    assert "small_text_under_10pt" in css
+
+
+def test_tokens_rejects_a_response_whose_token_count_does_not_match_its_colors(tmp_path):
+    p = tmp_path / "brand_package.json"
+    p.write_text(json.dumps(_response(token_count=4)))
+    out = _run("tokens", str(p))
+    assert out.returncode != 0
+    assert "token_count" in json.loads(out.stdout)["error"]
+
+
+def test_tokens_rejects_a_payload_missing_the_fields_only_the_tool_returns(tmp_path):
+    r = _response()
+    for k in ("brand_version", "usage_rules", "logo", "notes", "local_package_current"):
+        r.pop(k)
+    p = tmp_path / "brand_package.json"
+    p.write_text(json.dumps(r))
+    out = _run("tokens", str(p))
+    assert out.returncode != 0
+    assert "brand_version" in json.loads(out.stdout)["error"]
+
+
+def test_tokens_surfaces_a_stale_bundle_note_at_the_top_of_the_css(tmp_path):
+    p = tmp_path / "brand_package.json"
+    p.write_text(json.dumps(_response(local_package_current=False, local_version="2020.01",
+                                      notes=["Brand package mismatch: yours is 2020.01, ours is 2021.02."])))
+    out = _run("tokens", str(p))
+    assert out.returncode == 0
+    assert "Brand package mismatch" in out.stdout.splitlines()[0] or "mismatch" in out.stdout[:400].lower()
+
+
+def test_call_prints_the_exact_tool_call_to_make():
+    out = _run("call")
+    assert out.returncode == 0
+    d = json.loads(out.stdout)
+    assert d["tool"] == "pull_brand_package"
+    assert d["arguments"] == {"local_version": json.loads((SKILL / "brand-colors.json").read_text())["version"]}
+    assert d["save_as"] == "brand_package.json"
+
+
+def test_skill_md_drives_the_gate_command_and_names_the_tool_call_first():
+    text = (SKILL / "SKILL.md").read_text()
+    assert "brand.py call" in text and "brand.py tokens brand_package.json" in text
+    fm = text.split("---")[1]
+    desc = [l for l in fm.splitlines() if l.startswith("description:")][0]
+    # the router contract (G12) names the tool call before it advertises the bundled assets
+    assert desc.index("pull_brand_package") < desc.index("bundle")
+    assert "without asking the broker for files" not in desc


### PR DESCRIPTION
## What changed
A Lee-branded deliverable can no longer be composed from the files on disk alone: the render starts with `python3 brand.py call` (prints the `pull_brand_package` call to make) and `python3 brand.py tokens brand_package.json` (validates the saved response and prints the CSS the deliverable is built from). The command refuses the bundled `brand-colors.json`, so skipping the tool call leaves nothing to render from.

Refs #169 (broker-facing: stays open in QA through Stage 4).

## Root cause
Bonner's two 1.40.0 Sonnet runs (2026-09-03) shipped flyers with zero `pull_brand_package` rows in prod `audit_log`, the second with the connector provably on. The gate was prose. On the rig tonight (Sonnet 5 High, 1.41.1) the session DID attempt the call and stopped at the Desktop permission prompt (`evidence/gi169-repro-r5/06b-permission-dialog-zoom.png`), so the failure is model variance on a prose-only mandatory step, the class G33 records (`docs/superpowers/gotcha-registry.md`). The fix makes the step structural rather than chasing a repro.

## Mechanism (acceptance: "structurally hard to skip, state the mechanism and why")
- `brand.py tokens` accepts only a payload carrying the fields the Worker's response has and the bundled file lacks (`brand_version`, `local_package_current`, `usage_rules`, `logo`, `notes`, and a `token_count` that must equal the number of color entries). The bundled file's `{hex, pms, rgb, cmyk}` color objects are rejected explicitly with the instruction to call the tool.
- The render's brand color and type come from the printed `--lee-*` variables and `@font-face` block; SKILL.md's color section now points at those variables, not at the JSON.
- The skill description (the router contract, G12) names the tool call before it mentions the bundle, and no longer says "without asking the broker for files".
- A stale-bundle note from the tool is printed at the top of the CSS.

## Evidence
- `plugins/lee-internal-comps/tests/test_lee_branding_gate.py`: 7 cases (bundled file refused, response accepted with the expected CSS, token_count mismatch refused, missing tool-only fields refused, mismatch note surfaced, `call` output, SKILL.md drift incl. description order). Full suite 116 passed.
- Version 1.42.0 (minor: a new command in the broker path), both manifests, CHANGELOG.

## Checklist
- [x] Linked to issue (`Refs #169`, broker-facing)
- [x] Version bump: minor 1.42.0
- [x] `CHANGELOG.md` updated
- [x] `skill-contract-check`: lee-branding has no helpers.py so the check reports SKIP; the pytest suite is the gate
- [x] `superpowers:verification-before-completion` run (tests above; 4a owed: fresh Cowork Sonnet 5 runs of the teaser-flyer ask on 1.42.0, n>=3, each with a `pull_brand_package` audit row before any file, plus the connector-off negative run per lee#507 run 4)
- [x] Worktree cleanup planned for after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Scow6r12XNKzdza7Kr7GJ